### PR TITLE
Ensure all services start on reboot

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,6 +47,8 @@ Vagrant.configure("2") do |config|
   # Vulnerability - Setup for Glassfish
   config.vm.provision :shell, path: "scripts/installs/setup_glassfish.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
+  config.vm.provision :shell, path: "scripts/installs/start_glassfish_service.bat"
+  config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
 
   # Vulnerability - Jenkins (1.8)
   config.vm.provision :shell, path: "scripts/installs/setup_jenkins.bat"

--- a/scripts/installs/setup_apache_struts.bat
+++ b/scripts/installs/setup_apache_struts.bat
@@ -2,6 +2,7 @@ rm "%CATALINA_HOME%\conf\tomcat-users.xml"
 copy C:\vagrant\resources\apache_struts\tomcat-users.xml "%CATALINA_HOME%\conf\tomcat-users.xml"
 copy C:\vagrant\resources\apache_struts\server.xml "%CATALINA_HOME%\conf"
 
+sc config Tomcat8 start= auto
 net start "Apache Tomcat 8.0 Tomcat8"
 
 copy C:\vagrant\resources\apache_struts\struts2-rest-showcase.war "%CATALINA_HOME%\webapps"

--- a/scripts/installs/setup_glassfish.bat
+++ b/scripts/installs/setup_glassfish.bat
@@ -4,5 +4,4 @@ cmd /c ""C:\Program Files\7-Zip\7z.exe" x "C:\Windows\Temp\glassfish4.zip" -oC:\
 copy /Y "C:\vagrant\resources\glassfish\admin-keyfile" "C:\glassfish\glassfish4\glassfish\domains\domain1\config\admin-keyfile"
 copy /Y "C:\vagrant\resources\glassfish\domain.xml" "C:\glassfish\glassfish4\glassfish\domains\domain1\config\domain.xml"
 
-schtasks /create /tn "GlassFish" /tr "C:\glassfish\glassfish4\bin\asadmin.bat start-domain domain1" /sc onstart /np
-schtasks /run /tn "GlassFish"
+C:\glassfish\glassfish4\bin\asadmin.bat create-service domain1

--- a/scripts/installs/setup_jenkins.bat
+++ b/scripts/installs/setup_jenkins.bat
@@ -2,3 +2,4 @@ mkdir "%ProgramFiles%\jenkins"
 copy C:\vagrant\resources\jenkins\jenkins.war "%ProgramFiles%\jenkins"
 copy C:\vagrant\resources\jenkins\jenkins.exe "%ProgramFiles%\jenkins"
 "%ProgramFiles%\jenkins\jenkins.exe" -Service Install
+sc config jenkins start= auto

--- a/scripts/installs/start_glassfish_service.bat
+++ b/scripts/installs/start_glassfish_service.bat
@@ -1,0 +1,1 @@
+net start "domain1 GlassFish Server"


### PR DESCRIPTION
Make sure that all services start on boot to ensure a consistent environment (until you break something by trying to exploit it 😄 ). Had to add GlassFish as a service instead of a scheduled task (which is how it should have been to start) to accommodate this.

To Verify:
- [x] Use the instructions in [the wiki](https://github.com/rapid7/metasploitable3/wiki#building-metasploitable-3) to build the latest version.
- [x] Check each vulnerable service and ensure it is running.
- [x] Reboot the box and verify [all services](https://github.com/rapid7/metasploitable3/wiki/Vulnerabilities) are again running.