### PR TITLE
Add SNMP for Metasploitable3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -100,6 +100,10 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "scripts/installs/setup_axis2.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
 
+  # Vulnerability - SNMP
+  config.vm.provision :shell, path: "scripts/installs/setup_snmp.bat"
+  config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
+
   # Configure Firewall to open up vulnerable services
   config.vm.provision :shell, path: "scripts/configs/configure_firewall.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614

--- a/scripts/configs/configure_firewall.bat
+++ b/scripts/configs/configure_firewall.bat
@@ -12,3 +12,4 @@ netsh advfirewall firewall add rule name="Open Port 3306 for MySQL" dir=in actio
 netsh advfirewall firewall add rule name="Open Port 8020 for ManageEngine Desktop Central" dir=in action=allow protocol=TCP localport=8020
 netsh advfirewall firewall add rule name="Open Port 8383 for ManageEngine Desktop Central" dir=in action=allow protocol=TCP localport=8383
 netsh advfirewall firewall add rule name="Open Port 8022 for ManageEngine Desktop Central" dir=in action=allow protocol=TCP localport=8022
+netsh advfirewall firewall add rule name="Open Port 161 for SNMP" dir=in action=allow protocol=UDP localport=161

--- a/scripts/installs/setup_snmp.bat
+++ b/scripts/installs/setup_snmp.bat
@@ -1,0 +1,4 @@
+start /w PKGMGR.EXE /iu:SNMP
+reg delete HKLM\SYSTEM\ControlSet001\services\SNMP\Parameters\PermittedManagers /va /f
+reg add HKLM\SYSTEM\ControlSet001\services\SNMP\Parameters /v EnableAuthenticationTraps /t REG_DWORD /d 0 /f
+reg add HKLM\SYSTEM\ControlSet001\services\SNMP\Parameters\ValidCommunities /v public /t REG_DWORD /d 4 /f


### PR DESCRIPTION
This adds SNMP.

Verification:

- [x] ```vagrant destroy && vagrant up```
- [x] Make sure UDP port 161 is up
- [x] Use Metasploit module ```auxiliary/scanner/snmp/snmp_enum```
- [x] You should be able to see sensitive information such as processes, softwares installed, network info, and users, etc.