### PR TITLE
Make PhpMyAdmin only locally accessible 

### DIFF
--- a/resources/wamp/phpmyadmin.conf
+++ b/resources/wamp/phpmyadmin.conf
@@ -17,5 +17,6 @@ Alias /phpmyadmin "c:/wamp/apps/phpmyadmin3.4.10.1/"
     Options Indexes FollowSymLinks MultiViews
     AllowOverride all
         Order Deny,Allow
-	Allow from all
+        Deny from all
+        Allow from 127.0.0.1
 </Directory>


### PR DESCRIPTION
This makes PhpMyAdmin only locally accessible. However, if the server is compromised via another service, the attacker could create a pivot and connect to PhpMyAdmin anyway.

There is no MSF exploit for this PhpMyAdmin setup. If a pivot exists, the attacker can just connect to it with a browser.

Verification

- [x] ```vagrant destroy && vagrant up```
- [x] From the host machine, if you go to http://[ip]:8585/phpmyadmin, it should say access is forbidden
- [x] From the virtual machine, open IE, if you go to http://localhost:8585/phpmyadmin, you should be able to see PhpMyAdmin