### PR TITLE
Update GlashFish service permission

### DIFF
--- a/scripts/installs/setup_glassfish.bat
+++ b/scripts/installs/setup_glassfish.bat
@@ -5,3 +5,6 @@ copy /Y "C:\vagrant\resources\glassfish\admin-keyfile" "C:\glassfish\glassfish4\
 copy /Y "C:\vagrant\resources\glassfish\domain.xml" "C:\glassfish\glassfish4\glassfish\domains\domain1\config\domain.xml"
 
 C:\glassfish\glassfish4\bin\asadmin.bat create-service domain1
+
+sc config domain1 obj= "NT Authority\LOCAL SERVICE"
+icacls "C:\glassfish" /grant "NT Authority\LOCAL SERVICE:(OI)(CI)F" /T


### PR DESCRIPTION
GlassFish is running on a SYSTEM permission, which would make the box to easy.

Verification:

- [x] ```vagrant destroy && vagrant up```
- [x] Make sure port 4848 is up
- [x] Go to Control Panel, Services, double click on "domain1 GlassFish Server", and then click on the "Log On" tab. You should see that the service is running as "Local Service"