### PR TITLE
Increase base limits for WinRM connections

### DIFF
--- a/answer_files/2008_r2/Autounattend.xml
+++ b/answer_files/2008_r2/Autounattend.xml
@@ -143,19 +143,19 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxShellsPerUser="50"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxShellsPerUser="999"}</CommandLine>
                     <Description>Win RM MaxShellsPerUser</Description>
                     <Order>7</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxProcessesPerShell="50"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxProcessesPerShell="999"}</CommandLine>
                     <Description>Win RM MaxProcessesPerShell</Description>
                     <Order>8</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/service @{MaxConcurrentOperationsPerUser="50"}</CommandLine>
+                    <CommandLine>cmd.exe /c winrm set winrm/config/service @{MaxConcurrentOperationsPerUser="999"}</CommandLine>
                     <Description>Win RM ConcurrentOperationsPerUser</Description>
                     <Order>9</Order>
                     <RequiresUserInput>true</RequiresUserInput>

--- a/build_win2008.ps1
+++ b/build_win2008.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = "Stop"
 
-$virtualBoxMinVersion = "5.0.0"
+$virtualBoxMinVersion = "5.1.0"
 $packerMinVersion = "0.10.0"
-$vagrantMinVersion = "1.8.1"
+$vagrantMinVersion = "1.8.6"
 $vagrantreloadMinVersion = "0.0.1"
 
 function CompareVersions ($actualVersion, $expectedVersion, $exactMatch = $False) {
@@ -55,10 +55,10 @@ If ($(Test-Path "C:\HashiCorp\Vagrant\bin\vagrant.exe") -eq $True) {
     $vagrantVersion = $vagrantVersion.split(" ")[1]
 }
 
-If (CompareVersions -actualVersion $vagrantVersion -expectedVersion $vagrantMinVersion -exactVersion True) {
+If (CompareVersions -actualVersion $vagrantVersion -expectedVersion $vagrantMinVersion) {
     Write-Host "Compatible version of Vagrant found."
 } else {
-    Write-Host "Could not find a compatible version of Vagrant at C:\HashiCorp\Vagrant\bin\. At this time only $vagrantMinVersion is supported. Please download and install it from https://releases.hashicorp.com/vagrant/1.8.1/."
+    Write-Host "Could not find a compatible version of Vagrant at C:\HashiCorp\Vagrant\bin\. Please download and install it from https://www.vagrantup.com/downloads.html."
     exit
 }
 

--- a/build_win2008.sh
+++ b/build_win2008.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-min_virtualbox_ver="5.0.0"
-min_vagrant_ver="1.8.1"
+min_virtualbox_ver="5.1.0"
+min_vagrant_ver="1.8.6"
 min_packer_ver="0.10.0"
 min_vagrantreload_ver="0.0.1"
 
@@ -48,10 +48,10 @@ else
     exit 1
 fi
 
-if compare_versions $(vagrant -v | cut -d' ' -f2) $min_vagrant_ver true; then
+if compare_versions $(vagrant -v | cut -d' ' -f2) $min_vagrant_ver false; then
     echo 'Correct version of vagrant was found.'
 else
-    echo "A compatible version of vagrant was not found. At this time only $min_vagrant_ver is supported. Please install from here: https://releases.hashicorp.com/vagrant/1.8.1/"
+    echo "A compatible version of vagrant was not found. Please download and install it from https://www.virtualbox.org/wiki/Downloads."
     exit 1
 fi
 


### PR DESCRIPTION
Increase the connection limits for WinRM to workaround a [Vagrant bug ](https://github.com/mitchellh/vagrant/issues/7489). This should be resolved with the next official release of Vagrant, but this workaround should help things work out of the box until then.

Verification
- [x] Rebuild the base box from Packer by running `packer build windows_2008_r2.json`. If you already have metasploitable3 added to vagrant you will need to run `vagrant destroy`, then `vagrant box remove metasploitable3`, and add the new box with `vagrant box add windows_2008_r2_virtualbox.box --name=metasploitable3`
- [x] Provision the vagrant machine with `vagrant up`
- [x] Login and run `winrm get winrm/config/winrs`. The connection limits should be 999.
