### PR TITLE
Make difficulty configurable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,24 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+require 'getoptlong'
+
+opts = GetoptLong.new(
+  [ '--difficulty', GetoptLong::OPTIONAL_ARGUMENT ]
+)
+
+difficulty = :normal
+
+opts.each do |opt, arg|
+  case opt
+  when '--difficulty'
+    case arg
+    when /^easy$/i
+      difficulty = :easy
+    end
+  end
+end
+
 Vagrant.configure("2") do |config|
   # Base configuration for the VM and provisioner
   config.vm.box = "metasploitable3"
@@ -108,7 +126,13 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
 
   # Configure Firewall to open up vulnerable services
-  config.vm.provision :shell, path: "scripts/configs/configure_firewall.bat"
+  case difficulty
+  when :easy
+    config.vm.provision :shell, path: "scripts/configs/disable_firewall.bat"
+  when :normal
+    config.vm.provision :shell, path: "scripts/configs/configure_firewall.bat"
+  end
+
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
 
   # Vulnerability - ElasticSearch

--- a/scripts/configs/configure_firewall.bat
+++ b/scripts/configs/configure_firewall.bat
@@ -16,4 +16,3 @@ netsh advfirewall firewall add rule name="Closed port 139 for NetBIOS" dir=in ac
 netsh advfirewall firewall add rule name="Closed port 135 for NetBIOS" dir=in action=block protocol=TCP localport=135
 netsh advfirewall firewall add rule name="Closed Port 3389 for Remote Desktop" dir=in action=block protocol=TCP localport=3389
 netsh advfirewall firewall add rule name="Closed Port 3306 for MySQL" dir=in action=block protocol=TCP localport=3306
-netsh advfirewall firewall add rule name="Closed Port 5985 for WinRM" dir=in action=block protocol=TCP localport=5985

--- a/scripts/configs/disable_firewall.bat
+++ b/scripts/configs/disable_firewall.bat
@@ -1,0 +1,1 @@
+netsh advfirewall set allprofiles state off


### PR DESCRIPTION
This allows Metasploitable3 to have two levels of difficulty: easy and normal
- **Easy:** The firewall is off completely
- **Normal:** Only HTTP-based services (IIS, Apache, ManageEngine, GlassFish, etc) are not protected by the firewall, but they run on LOCAL SERVICE. The other higher privilege services are protected by the firewall.

Verification
- [ ] `vagrant destroy & vagrant up`
- [ ] Do a nmap against the box. You should be in the normal mode.
- [ ] `vagrant destroy & vagrant --difficulty=easy up`
- [ ] Do a nmap scan again. You should see all the ports are open.
