### PR TITLE
Adding support for VMware

### DIFF
--- a/vagrantfile-windows_2008_r2.template
+++ b/vagrantfile-windows_2008_r2.template
@@ -7,6 +7,7 @@ Vagrant.configure("2") do |config|
     config.vm.define "vagrant-windows-2008-r2"
     config.vm.box = "windows_2008_r2"
     config.vm.communicator = "winrm"
+    #config.vm.provider = ""  # Replace with "vmware_fusion" or "vmware_workstation" if using vmware
 
     # Admin user name and password
     config.winrm.username = "vagrant"

--- a/windows_2008_r2_vmware.json
+++ b/windows_2008_r2_vmware.json
@@ -1,0 +1,65 @@
+{
+  "builders": [
+    {
+      "type": "vmware-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": true,
+      "boot_wait": "2m",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "guest_os_type": "windows8-64",
+      "disk_size": 61440,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/configs/microsoft-updates.bat",
+        "./scripts/configs/win-updates.ps1",
+        "./scripts/installs/openssh.ps1",
+        "./resources/certs/oracle-cert.cer",
+        "./resources/certs/gdig2.crt",
+        "./resources/certs/comodorsadomainvalidationsecureserverca.crt",
+        "./resources/certs/comodorsacertificationauthority.crt",
+        "./resources/certs/addtrust_external_ca.cer",
+        "./resources/certs/baltimore_ca.cer",
+        "./resources/certs/digicert.cer",
+        "./resources/certs/equifax.cer",
+        "./resources/certs/globalsign.cer",
+        "./resources/certs/gte_cybertrust.cer",
+        "./resources/certs/microsoft_root_2011.cer",
+        "./resources/certs/thawte_primary_root.cer",
+        "./resources/certs/utn-userfirst.cer"
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "remote_path": "/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
+      "scripts": [
+        "./scripts/installs/vm-guest-tools.bat",
+        "./scripts/configs/vagrant-ssh.bat",
+        "./scripts/configs/disable-auto-logon.bat",
+        "./scripts/configs/enable-rdp.bat",
+        "./scripts/configs/update_root_certs.bat"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "keep_input_artifact": false,
+      "output": "windows_2008_r2_{{.Provider}}.box",
+      "vagrantfile_template": "vagrantfile-windows_2008_r2.template"
+    }
+  ],
+  "variables": {
+    "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "4263be2cf3c59177c45085c0a7bc6ca5",
+    "autounattend": "./answer_files/2008_r2/Autounattend.xml"
+  }
+}


### PR DESCRIPTION
This diff creates a separate Packer configuration that will successfully build for VMware fusion.

Issues addressed: https://github.com/rapid7/metasploitable3/issues/55

Use Case: I already have Fusion installed and I didn't want to install VirtualBox adjacent to it on the same box.

Notes: It's probably worth mentioning in the docs that a paid VMware vagrant provider is required to build this for VMware.

If you'd like me to update the documentation to include a reference to building for VMware, I'm also happy to do that as well.