### PR TITLE
Fix VirtualBox version check in PowerShell build script

### DIFF
--- a/build_win2008.ps1
+++ b/build_win2008.ps1
@@ -34,7 +34,7 @@ If ($(Test-Path "C:\Program Files\Oracle\VirtualBox\VBoxManage.exe") -eq $True) 
     $vboxVersion = $vboxVersion.split("r")[0]
 }
 
-If (CompareVersions -actualVersion $vboxVersion -expectedVersion $virtualBoxMinVersion --exactMatch $False) {
+If (CompareVersions -actualVersion $vboxVersion -expectedVersion $virtualBoxMinVersion -exactMatch $False) {
     Write-Host "Compatible version of VirtualBox found."
 } else {
     Write-Host "Could not find a compatible version of VirtualBox at C:\Program Files\Oracle\VirtualBox\. Please download and install it from https://www.virtualbox.org/"


### PR DESCRIPTION
this is in response to issue #78 "build_win2008.ps1 Failing version check"

removed leading dash from exactMatch parameter call on line 37 of `build_win2008.ps1`

exactMatch sent the string "--exactMatch" to the CompareVersions function instead of $False, so the exactMatch if statement always executed in CompareVersions. Newer versions of VirtualBox would fail the version check