### PR TITLE
Updated the initial startup time for Elasticsearch

### DIFF
--- a/scripts/installs/install_elasticsearch.bat
+++ b/scripts/installs/install_elasticsearch.bat
@@ -3,7 +3,7 @@ cmd /c ""C:\Program Files\7-Zip\7z.exe" x "C:\Windows\Temp\elasticsearch-1.1.1.z
 cmd /c ""C:\Program Files\elasticsearch-1.1.1\bin\service.bat" install"
 sc config "elasticsearch-service-x64" start= auto
 cmd /c ""C:\Program Files\elasticsearch-1.1.1\bin\service.bat" start"
-powershell -Command "Start-Sleep -s 5"
+powershell -Command "Start-Sleep -s 30"
 powershell -Command "$req = [System.Net.HttpWebRequest]::Create('http://localhost:9200/metasploitable3/'); $req.method = 'PUT'; $req.GetResponse()"
 powershell -Command "$body = [System.Text.Encoding]::ASCII.GetBytes('{\"user\":\"kimchy\", \"post_date\": \"2009-11-15T14:12:12\", \"message\": \"Elasticsearch\" }'); $req = [System.Net.HttpWebRequest]::Create('http://localhost:9200/metasploitable3/message/1'); $req.method = 'PUT'; $req.ContentType = 'application/x-www-form-urlencoded'; $stream = $req.GetRequestStream(); $stream.Write($body, 0, $body.Length); $stream.close(); $req.GetResponse()"
 


### PR DESCRIPTION
Updated from 5 seconds to 30 seconds in order to accommodate different machine startup times. This is currently a quick fix. A more optimal solution may have to be researched. Refer to issue #63 for more details.