### PR TITLE
Enhanced VBox version check error msgs for PS.

### DIFF
--- a/build_win2008.ps1
+++ b/build_win2008.ps1
@@ -29,15 +29,22 @@ function CompareVersions ($actualVersion, $expectedVersion, $exactMatch = $False
     return $True
 }
 
-If ($(Test-Path "C:\Program Files\Oracle\VirtualBox\VBoxManage.exe") -eq $True) {
-    $vboxVersion = cmd.exe /c "C:\Program Files\Oracle\VirtualBox\VBoxManage.exe" -v
+$expectedVBoxLocation = "C:\Program Files\Oracle\VirtualBox"
+If ($(Test-Path "$expectedVBoxLocation\VBoxManage.exe") -eq $True) {
+    $vboxVersion = cmd.exe /c "$expectedVBoxLocation\VBoxManage.exe" -v
     $vboxVersion = $vboxVersion.split("r")[0]
+} else {
+    Write-Host "VirtualBox is not installed (or not in the expected location of $expectedVBoxLocation\)"
+    Write-Host "Please download and install it from https://www.virtualbox.org/"
+    exit
 }
 
 If (CompareVersions -actualVersion $vboxVersion -expectedVersion $virtualBoxMinVersion -exactMatch $False) {
     Write-Host "Compatible version of VirtualBox found."
 } else {
-    Write-Host "Could not find a compatible version of VirtualBox at C:\Program Files\Oracle\VirtualBox\. Please download and install it from https://www.virtualbox.org/"
+    Write-Host "A compatible version of VirtualBox was not found."
+    Write-Host "Current Version=[$vboxVersion], Minimum Version=[$virtualBoxMinVersion]"
+    Write-Host "Please download and install it from https://www.virtualbox.org/"
     exit
 }
 


### PR DESCRIPTION
Companion PR to #61, this one adds the enhanced VBox version checking messages to PowerShell build script for Windows users.  I verified it works-as-expected on a Windows 10 laptop at home.

An additional comment here: it'd probably be nice to add similar messages for the packer and vagrant version checking, as well (in both the PowerShell and bash build scripts).

#### VirtualBox not found
![vbox-not-found](https://cloud.githubusercontent.com/assets/19912177/23614302/15740af2-0248-11e7-9e19-21ba46d7bdeb.png)

#### VirtualBox version too old
![vbox-ver-too-old](https://cloud.githubusercontent.com/assets/19912177/23614337/2f688122-0248-11e7-9d6c-7b363e9e079e.png)

## Verification

The steps needed to make sure this thing works:

On a Windows system without VBox installed:

- [ ] open a PowerShell window
- [ ] run `build_win2008.ps1`
- **Verify** you see an error message that VBox doesn't appear to be installed and that the script stops

On a Windows system with an "old" (pre 5.1.0) version of VBox installed:

- [ ] open a PowerShell window
- [ ] run `build_win2008.ps1`
- **Verify** you see an error message that the version of VBox does not meet the minimum-required version and the script stops

On a Windows system with a "new enough"  (5.1.10 or later) version of VBox installed:

- [ ] open a PowerShell window
- [ ] run `build_win2008.ps1`
- **Verify** you see a message that the script found a "compatible version" of VBox and that it tries to build