### PR TITLE
Add unrealircd Vulnerable Service

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -164,6 +164,7 @@ Vagrant.configure("2") do |config|
       chef.add_recipe "metasploitable::sinatra"
       chef.add_recipe "metasploitable::docker"
       chef.add_recipe "metasploitable::samba"
+      chef.add_recipe "metasploitable::unrealircd"
     end
   end
 end

--- a/chef/cookbooks/metasploitable/files/unrealircd/unrealircd
+++ b/chef/cookbooks/metasploitable/files/unrealircd/unrealircd
@@ -1,0 +1,37 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          unrealircd
+# Required-Start:    $local_fs
+# Required-Stop:     $local_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# X-Interactive:     false
+# Short-Description: Init script for unrealircd
+# Description:       Start/stop unrealircd
+### END INIT INFO
+
+DESC="unrealircd"
+NAME=unrealircd
+#DAEMON=
+
+do_start()
+{
+   /opt/unrealircd/Unreal3.2/unreal start
+}
+
+do_stop()
+{
+   /opt/unrealircd/Unreal3.2/unreal stop
+}
+
+
+case "$1" in
+   start)
+     do_start
+     ;;
+   stop)
+     do_stop
+     ;;
+esac
+
+exit 0

--- a/chef/cookbooks/metasploitable/files/unrealircd/unrealircd.conf
+++ b/chef/cookbooks/metasploitable/files/unrealircd/unrealircd.conf
@@ -1,0 +1,218 @@
+#Example UnrealIRCd 3.2.8.1 configuration file
+#Written by Mp5shooter for the SwiftIRC Wiki
+#http://wiki.SwiftIRC.net/
+
+/* If your server is running Linux, remove the two slashes in front of both of the following lines. */
+loadmodule "src/modules/commands.so";
+loadmodule "src/modules/cloak.so";
+
+/* If your server is running Windows, remove the two slashes in front of both of the following lines. */
+//loadmodule "modules/commands.dll";
+//loadmodule "modules/cloak.dll";
+
+#This is the me {} block
+me {
+	name "irc.TestIRC.net";
+	info "Test IRC Server";
+	numeric 1;
+};
+
+#This is the admin {} block
+admin {
+	"Mp5 Shooter";
+	"Mp5@TestIRC.net";
+};
+
+#This is the oper {} block
+oper YourName {
+	class           clients;
+	from {
+		userhost Me@and.my.host;
+	};
+	password "ILiKEopeRING1022";
+	flags
+	{
+		netadmin;
+		can_zline;
+		can_gzline;
+		can_gkline;
+		global;
+	};
+};
+
+#This is the services link block
+/*
+link            services.TestIRC.net
+{
+ 	username	*;
+	hostname 	127.0.0.1;
+	bind-ip 	*;
+	port 		6667;
+	hub             *;
+	password-connect "Sup3rSERViCE";
+	password-receive "Sup3rSERViCE";
+	class           servers;
+};
+*/
+
+#This is the ulines block
+ulines {
+	services.TestIRC.net;
+};
+
+#START OF BAN BLOCKS
+ban nick {
+	mask "*C*h*a*n*S*e*r*v*";
+	reason "Reserved for Services";
+};
+
+ban ip {
+	mask 195.86.232.81;
+	reason "Noob";
+};
+
+ban user {
+	mask *tirc@*.saturn.bbn.com;
+        reason "Idiot";
+};
+
+ban realname {
+	mask "Swat Team";
+	reason "mIRKFORCE";
+};
+
+except ban {
+	/* don't ban Mp5shooter :) */
+	mask           *Mp5shooter@adsl-074*;
+};
+
+deny channel {
+	channel "*warez*";
+	reason "Warez is illegal";
+};
+#END OF BAN BLOCKS
+
+#This is the vHost block
+vhost {
+	vhost           super.cool.irc.dude;
+	from {
+		userhost       *@*;
+	};
+	login           YourName;
+	password        LovingTheKwlHost;
+};
+
+#This is the network settings block
+set {
+	network-name 		"TestIRC";
+	default-server 		"irc.TestIRC.net";
+	services-server 	"services.TestIRC.net";
+	stats-server 		"stats.TestIRC.net";
+	help-channel 		"#Help";
+	hiddenhost-prefix	"Test";
+	cloak-keys {
+		"KIuoehnfOush230uNSDL309subnsA";
+		"Jk93uKLsd30skSHNfel39wLKHd3ws";
+		"Iehnludhnfe83KLBDHef39ekHBD44";
+	};
+	hosts {
+		local		"locop.TestIRC.net";
+		global		"ircop.TestIRC.net";
+		coadmin		"coadmin.TestIRC.net";
+		admin		"admin.TestIRC.net";
+		servicesadmin 	"csops.TestIRC.net";
+		netadmin 	"netadmin.TestIRC.net";
+		host-on-oper-up "no";
+	};
+};
+
+#This is the server settings block
+set {
+	kline-address "admin@TestIRC.net";
+	modes-on-connect "+ix";
+	modes-on-oper	 "+xwgs";
+	oper-auto-join "#opers";
+	options {
+		show-connect-info;
+	};
+	maxchannelsperuser 30;
+	anti-spam-quit-message-time 10s;
+	oper-only-stats "okfGsMRUEelLCXzdD";
+	throttle {
+		connections 3;
+		period 60s;
+	};
+	anti-flood {
+		nick-flood 3:60;
+	};
+	spamfilter {
+		ban-time 1d;
+		ban-reason "Spam/Advertising";
+		virus-help-channel "#help";
+	};
+};
+
+#Do not edit anything below this line, unless you know what you are doing
+
+include "help.conf";
+include "badwords.channel.conf";
+include "badwords.message.conf";
+include "badwords.quit.conf";
+include "spamfilter.conf";
+
+class           clients
+{
+	pingfreq 90;
+	maxclients 500;
+	sendq 100000;
+	recvq 8000;
+};
+
+class           servers
+{
+	pingfreq 90;
+	maxclients 10;
+	sendq 1000000;
+	connfreq 100;
+};
+
+allow {
+	ip             *@*;
+	hostname       *@*;
+	class           clients;
+	maxperip 5;
+};
+
+listen         *:6697
+{
+	options
+	{
+		ssl;
+		clientsonly;
+	};
+};
+
+listen         *:8067;
+listen         *:6667;
+
+log "ircd.log" {
+	maxsize 2097152;
+	flags {
+		oper;
+		kline;
+		connects;
+		server-connects;
+		kills;
+		errors;
+		sadmin-commands;
+		chg-commands;
+		oper-override;
+		spamfilter;
+	};
+};
+
+alias NickServ { type services; };
+alias ChanServ { type services; };
+alias OperServ { type services; };
+alias HelpServ { type services; };
+include "aliases/anope.conf";

--- a/chef/cookbooks/metasploitable/recipes/unrealircd.rb
+++ b/chef/cookbooks/metasploitable/recipes/unrealircd.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook:: metasploitable
+# Recipe:: unrealircd.rb
+#
+# Copyright:: 2017, Rapid7, All Rights Reserved.
+
+# Downloaded from https://www.exploit-db.com/exploits/13853/
+# Install steps taken from https://wiki.swiftirc.net/wiki/Installing_and_Configuring_UnrealIRCd_on_Linux
+
+bash 'download and extract UnrealIRCd' do
+  code <<-EOH
+    wget -c -t 3 -O /tmp/Unreal3.2.8.1_backdoor.tar.gz https://www.exploit-db.com/apps/752e46f2d873c1679fa99de3f52a274d-Unreal3.2.8.1_backdoor.tar_.gz
+    mkdir /opt/unrealircd
+    tar xvfz /tmp/Unreal3.2.8.1_backdoor.tar.gz -C /opt/unrealircd
+    chmod 755 /opt/unrealircd/Unreal3.2
+  EOH
+end
+
+cookbook_file '/opt/unrealircd/Unreal3.2/unrealircd.conf' do
+  source 'unrealircd/unrealircd.conf'
+end
+
+bash 'configure and compile' do
+  code <<-EOH
+    cd /opt/unrealircd/Unreal3.2
+    ./configure --with-showlistmodes --enable-hub --enable-prefixaq --with-listen=5 --with-dpath=/opt/unrealircd/Unreal3.2 --with-spath=/opt/unrealircd/Unreal3.2/src/ircd --with-nick-history=2000 --with-sendq=3000000 --with-bufferpool=18 --with-hostname=metasploitableub --with-permissions=0600 --with-fd-setsize=1024 --enable-dynamic-linking
+    make
+  EOH
+end
+
+cookbook_file '/etc/init.d/unrealircd' do
+  source 'unrealircd/unrealircd'
+  mode '760'
+end
+
+service 'unrealircd' do
+  action [:enable, :start]
+end


### PR DESCRIPTION
This PR adds a new vulnerable service to the Linux VM, UnrealIRCd 3.2.8.1. This version was released with a backdoor used maliciously to access machines running the service.

Verification:
- [x] `vagrant up`
- [x] Logon to the VM and verify an app is listening on TCP 6667
- [x] Verify you can start and stop the service using `sudo service unrealircd start/stop`
- [x] Verify the exploits/unix/irc/unreal_ircd_3281_backdoor module in Metasploit Framework is able to get a shell