### PR TITLE
Mount a share from Linux samba

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,6 +126,10 @@ Vagrant.configure("2") do |config|
     win2k8.vm.provision :shell, path: "scripts/installs/install_elasticsearch.bat"
     win2k8.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
 
+    # Insecure share from the Linux machine
+    win2k8.vm.provision :shell, path: "scripts/installs/setup_linux_share.bat"
+    win2k8.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
+
     # Configure flags
     win2k8.vm.provision :shell, path: "scripts/installs/install_flags.bat"
     win2k8.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614a
@@ -135,7 +139,7 @@ Vagrant.configure("2") do |config|
     trusty.vm.box = "rsginc/ubuntu64-14-04-1"
     trusty.vm.hostname = "metasploitableUB"
 
-    trusty.vm.network "private_network", type: "dhcp"
+    trusty.vm.network "private_network", ip: '172.28.128.3'
 
     trusty.vm.provider "virtualbox" do |v|
       v.name = "MetasploitableUB"

--- a/scripts/installs/setup_linux_share.bat
+++ b/scripts/installs/setup_linux_share.bat
@@ -1,0 +1,6 @@
+@echo off
+ping -n 1 -4 172.28.128.3 | find /i "TTL=" > nul
+IF ERRORLEVEL 1 (echo "Linux host not available.") ELSE (
+  cmdkey /add:172.28.128.3 /user:chewbacca /pass:rwaaaaawr5
+  net use W: \\172.28.128.3\public /savecred /p:yes
+)


### PR DESCRIPTION
This adds a share that allows the attacker to upload malicious files onto the Linux machine.

Verification

- [x] ```vagrant up``` the Linux machine
- [x] ```vagrant up``` the Windows machine
- [x] Go to the Linux machine, and go to "My Computer", you should see the "public" share like the following:

![screen shot 2017-04-07 at 2 35 18 pm](https://cloud.githubusercontent.com/assets/1170914/24816735/7a678824-1b9f-11e7-85a1-8cf057524100.png)

- [x] ```vagrant destroy``` both machines
- [x] ```vagrant up``` the Windows machine again.
- [x] The Windows machine should complete the build without any errors.