### PR TITLE
Add chatbot to Linux VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -169,6 +169,7 @@ Vagrant.configure("2") do |config|
       chef.add_recipe "metasploitable::docker"
       chef.add_recipe "metasploitable::samba"
       chef.add_recipe "metasploitable::unrealircd"
+      chef.add_recipe "metasploitable::chatbot"
     end
   end
 end

--- a/chef/cookbooks/metasploitable/recipes/chatbot.rb
+++ b/chef/cookbooks/metasploitable/recipes/chatbot.rb
@@ -1,18 +1,22 @@
 #
-# Cookbook:: chatbot
+# Cookbook:: metasploitable
 # Recipe:: chatbot
 #
 # Copyright:: 2017, Rapid7, All Rights Reserved.
 #
 #
 
-include_recipe 'metasploitable::chatbot'
+include_recipe 'metasploitable::ruby23'
+include_recipe 'metasploitable::nodejs'
 
 package 'unzip'
 
-package 'npm'
-
-package 'bundler'
+bash "Install dependencies" do
+  code <<-EOH
+    npm install express
+    npm install cors
+  EOH
+end
 
 cookbook_file '/tmp/chatbot.zip' do
   source 'chatbot/chatbot.zip'

--- a/chef/cookbooks/metasploitable/recipes/chatbot.rb
+++ b/chef/cookbooks/metasploitable/recipes/chatbot.rb
@@ -1,0 +1,41 @@
+#
+# Cookbook:: sinatra
+# Recipe:: sinatra
+#
+# Copyright:: 2017, Rapid7, All Rights Reserved.
+#
+#
+
+include_recipe 'metasploitable::sinatra'
+
+package 'unzip'
+
+package 'npm'
+
+package 'bundler'
+
+cookbook_file '/tmp/chatbot.zip' do
+  source 'chatbot/chatbot.zip'
+  mode '0777'
+end
+
+execute 'unzip chatbot' do
+  command 'unzip /tmp/chatbot.zip -d /opt'
+end
+
+execute 'chown chatbot' do
+  command 'chown -R vagrant:vagrant /opt/chatbot'
+end
+
+execute 'chmod chatbot' do
+  command 'chmod -R 777 /opt/chatbot'
+end
+
+execute 'install chatbot' do
+  command '/opt/chatbot/install.sh'
+end
+
+service 'chatbot' do
+  supports restart: false, start: true, reload: false, status: false
+  action [:enable, :start]
+end

--- a/chef/cookbooks/metasploitable/recipes/chatbot.rb
+++ b/chef/cookbooks/metasploitable/recipes/chatbot.rb
@@ -1,12 +1,12 @@
 #
-# Cookbook:: sinatra
-# Recipe:: sinatra
+# Cookbook:: chatbot
+# Recipe:: chatbot
 #
 # Copyright:: 2017, Rapid7, All Rights Reserved.
 #
 #
 
-include_recipe 'metasploitable::sinatra'
+include_recipe 'metasploitable::chatbot'
 
 package 'unzip'
 

--- a/chef/cookbooks/metasploitable/recipes/nodejs.rb
+++ b/chef/cookbooks/metasploitable/recipes/nodejs.rb
@@ -6,9 +6,12 @@
 #
 #
 
+execute 'add nodejs 4 repository' do
+  command 'curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -'
+end
+
 execute "apt-get update" do
   command "apt-get update"
 end
 
 package 'nodejs'
-package 'npm'

--- a/chef/cookbooks/metasploitable/recipes/nodejs.rb
+++ b/chef/cookbooks/metasploitable/recipes/nodejs.rb
@@ -1,0 +1,14 @@
+#
+# Cookbook:: metasploitable
+# Recipe:: nodejs
+#
+# Copyright:: 2017, Rapid7, All Rights Reserved.
+#
+#
+
+execute "apt-get update" do
+  command "apt-get update"
+end
+
+package 'nodejs'
+package 'npm'

--- a/chef/cookbooks/metasploitable/recipes/readme_app.rb
+++ b/chef/cookbooks/metasploitable/recipes/readme_app.rb
@@ -7,9 +7,9 @@
 #
 
 include_recipe 'metasploitable::ruby23'
+include_recipe 'metasploitable::nodejs'
 
 package 'git'
-package 'nodejs'
 
 directory '/opt/readme_app' do
   mode '0777'

--- a/chef/cookbooks/metasploitable/recipes/sinatra.rb
+++ b/chef/cookbooks/metasploitable/recipes/sinatra.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook:: sinatra
+# Cookbook:: metasploitable
 # Recipe:: sinatra
 #
 # Copyright:: 2017, Rapid7, All Rights Reserved.


### PR DESCRIPTION
## Description

This adds a vulnerability that allows CORS + command injection on a localhost service. It contains 3 components: a chatroom at metasploitable3ub/chat/, a chatroom client, and a features service for the bot that is meant for special features (in this case, looking up a system user)

## Verification

- [x] vagrant up trusty
- [x] Go to http://metasploitable3ub/chat/index.php
- [x] Enter the chatroom with a name
- [x] In the chatroom, type ```hi```
- [x] The bot should say "aloha" back to you, this indicates the bot is working.