### PR TITLE
Add vulnerable service cups.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -169,6 +169,7 @@ Vagrant.configure("2") do |config|
       chef.add_recipe "metasploitable::docker"
       chef.add_recipe "metasploitable::samba"
       chef.add_recipe "metasploitable::unrealircd"
+      chef.add_recipe "metasploitable::cups"
     end
   end
 end

--- a/chef/cookbooks/metasploitable/files/cups/cupsd.conf
+++ b/chef/cookbooks/metasploitable/files/cups/cupsd.conf
@@ -13,8 +13,8 @@ LogLevel warn
 MaxLogSize 0
 
 # Only listen for connections from the local machine.
-Listen *:631
-Listen /var/run/cups/cups.sock
+Port 631
+#Listen /var/run/cups/cups.sock
 
 # Show shared printers on the local network.
 Browsing Off

--- a/chef/cookbooks/metasploitable/files/cups/cupsd.conf
+++ b/chef/cookbooks/metasploitable/files/cups/cupsd.conf
@@ -1,0 +1,140 @@
+#
+#
+# Sample configuration file for the CUPS scheduler.  See "man cupsd.conf" for a
+# complete description of this file.
+#
+
+# Log general information in error_log - change "warn" to "debug"
+# for troubleshooting...
+LogLevel warn
+
+# Deactivate CUPS' internal logrotating, as we provide a better one, especially
+# LogLevel debug2 gets usable now
+MaxLogSize 0
+
+# Only listen for connections from the local machine.
+Listen *:631
+Listen /var/run/cups/cups.sock
+
+# Show shared printers on the local network.
+Browsing Off
+BrowseLocalProtocols dnssd
+
+# Default authentication type, when authentication is required...
+DefaultAuthType Basic
+
+# Web interface setting...
+WebInterface Yes
+
+# Restrict access to the server...
+<Location />
+  Order allow,deny
+  Allow from all
+</Location>
+
+# Restrict access to the admin pages...
+<Location /admin>
+  Order allow,deny
+  Allow from all
+</Location>
+
+# Restrict access to configuration files...
+<Location /admin/conf>
+  AuthType Default
+  Require user @SYSTEM
+  Order allow,deny
+  Allow from all
+</Location>
+
+# Set the default printer/job policies...
+<Policy default>
+  # Job/subscription privacy...
+  JobPrivateAccess default
+  JobPrivateValues default
+  SubscriptionPrivateAccess default
+  SubscriptionPrivateValues default
+
+  # Job-related operations must be done by the owner or an administrator...
+  <Limit Create-Job Print-Job Print-URI Validate-Job>
+    Order deny,allow
+  </Limit>
+
+  <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document>
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All administration operations require an administrator to authenticate...
+  <Limit CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default CUPS-Get-Devices>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All printer operations require a printer operator to authenticate...
+  <Limit Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After Cancel-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # Only the owner or an administrator can cancel or authenticate a job...
+  <Limit Cancel-Job CUPS-Authenticate-Job>
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  <Limit All>
+    Order deny,allow
+  </Limit>
+</Policy>
+
+# Set the authenticated printer/job policies...
+<Policy authenticated>
+  # Job/subscription privacy...
+  JobPrivateAccess default
+  JobPrivateValues default
+  SubscriptionPrivateAccess default
+  SubscriptionPrivateValues default
+
+  # Job-related operations must be done by the owner or an administrator...
+  <Limit Create-Job Print-Job Print-URI Validate-Job>
+    AuthType Default
+    Order deny,allow
+  </Limit>
+
+  <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document>
+    AuthType Default
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All administration operations require an administrator to authenticate...
+  <Limit CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All printer operations require a printer operator to authenticate...
+  <Limit Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After Cancel-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # Only the owner or an administrator can cancel or authenticate a job...
+  <Limit Cancel-Job CUPS-Authenticate-Job>
+    AuthType Default
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  <Limit All>
+    Order deny,allow
+    Allow from all
+  </Limit>
+</Policy>
+
+#
+#

--- a/chef/cookbooks/metasploitable/recipes/cups.rb
+++ b/chef/cookbooks/metasploitable/recipes/cups.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook:: metasploitable
+# Recipe:: cups
+#
+# Copyright:: 2017, Rapid7, All Rights Reserved.
+
+execute 'apt-get update' do
+  command 'apt-get update'
+end
+
+package 'cups' do
+  action :install
+end
+
+cookbook_file '/etc/cups/cupsd.conf' do
+  source 'cups/cupsd.conf'
+  mode '0644'
+end
+
+service 'cups' do
+  action [:enable, :start]
+end

--- a/chef/cookbooks/metasploitable/recipes/cups.rb
+++ b/chef/cookbooks/metasploitable/recipes/cups.rb
@@ -18,5 +18,5 @@ cookbook_file '/etc/cups/cupsd.conf' do
 end
 
 service 'cups' do
-  action [:enable, :start]
+  action [:enable, :restart]
 end


### PR DESCRIPTION
This PR adds a vulnerable configuration of cups. It allows access on port 631 to the cups administration page and is exploitable using exploit/multi/http/cups_bash_env_exec.

Verification:
- [x] Build the linux VM using `vagrant up trusty`
- [x] Open up msfconsole and enter `use exploit/multi/http/cups_bash_env_exec`
- [ ] Set the RHOST to the IP of the VM, HttpUsername to `vagrant` and HttpPassword to `vagrant`
- [ ] Run the module. You should be able to get a session.