### PR TITLE
Add ReadMe Rails App

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -169,6 +169,7 @@ Vagrant.configure("2") do |config|
       chef.add_recipe "metasploitable::docker"
       chef.add_recipe "metasploitable::samba"
       chef.add_recipe "metasploitable::unrealircd"
+      chef.add_recipe "metasploitable::readme_app"
     end
   end
 end

--- a/chef/cookbooks/metasploitable/files/readme_app/readme_app
+++ b/chef/cookbooks/metasploitable/files/readme_app/readme_app
@@ -1,0 +1,40 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          readme_app
+# Required-Start:    $local_fs
+# Required-Stop:     $local_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# X-Interactive:     false
+# Short-Description: Init script for readme_app
+# Description:       Start/stop readme_app
+### END INIT INFO
+
+DESC="readme_app"
+NAME=readme_app
+#DAEMON=
+
+do_start()
+{
+   echo "Starting readme_app.";
+   cd /opt/readme_app
+   rails s &
+}
+
+do_stop()
+{
+   echo "Stopping readme_app."
+   killall ruby
+}
+
+
+case "$1" in
+   start)
+     do_start
+     ;;
+   stop)
+     do_stop
+     ;;
+esac
+
+exit 0

--- a/chef/cookbooks/metasploitable/files/readme_app/readme_app.conf
+++ b/chef/cookbooks/metasploitable/files/readme_app/readme_app.conf
@@ -1,0 +1,5 @@
+description 'Run ReadMe App'
+author 'metasploitable3'
+
+start on runlevel [2345]
+exec "/opt/readme_app/start.sh"

--- a/chef/cookbooks/metasploitable/files/readme_app/start.sh
+++ b/chef/cookbooks/metasploitable/files/readme_app/start.sh
@@ -2,4 +2,4 @@
 
 cd /opt/readme_app
 bundle install
-rails s -b 0.0.0.0
+rails s -b 0.0.0.0 -p 3500

--- a/chef/cookbooks/metasploitable/files/readme_app/start.sh
+++ b/chef/cookbooks/metasploitable/files/readme_app/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd /opt/readme_app
+bundle install
+rails s -b 0.0.0.0

--- a/chef/cookbooks/metasploitable/recipes/readme_app.rb
+++ b/chef/cookbooks/metasploitable/recipes/readme_app.rb
@@ -9,6 +9,7 @@
 include_recipe 'metasploitable::ruby23'
 
 package 'git'
+package 'nodejs'
 
 directory '/opt/readme_app' do
   mode '0777'
@@ -18,16 +19,20 @@ bash "clone the readme app and install gems" do
   code <<-EOH
     cd /opt/
     git clone https://github.com/jbarnett-r7/metasploitable3-readme.git readme_app
-    cd readme_app
-    bundle install
   EOH
 end
 
-cookbook_file '/etc/init.d/readme_app' do
-  source 'readme_app/readme_app'
-  mode '760'
+cookbook_file '/opt/readme_app/start.sh' do
+  source 'readme_app/start.sh'
+  mode '0777'
+end
+
+cookbook_file '/etc/init/readme_app.conf' do
+  source 'readme_app/readme_app.conf'
+  mode '0777'
 end
 
 service 'readme_app' do
+  supports restart: false, start: true, reload: false, status: false
   action [:enable, :start]
 end

--- a/chef/cookbooks/metasploitable/recipes/readme_app.rb
+++ b/chef/cookbooks/metasploitable/recipes/readme_app.rb
@@ -1,0 +1,33 @@
+#
+# Cookbook:: metasploitable
+# Recipe:: readme_app
+#
+# Copyright:: 2017, Rapid7, All Rights Reserved.
+#
+#
+
+include_recipe 'metasploitable::ruby23'
+
+package 'git'
+
+directory '/opt/readme_app' do
+  mode '0777'
+end
+
+bash "clone the readme app and install gems" do
+  code <<-EOH
+    cd /opt/
+    git clone https://github.com/jbarnett-r7/metasploitable3-readme.git readme_app
+    cd readme_app
+    bundle install
+  EOH
+end
+
+cookbook_file '/etc/init.d/readme_app' do
+  source 'readme_app/readme_app'
+  mode '760'
+end
+
+service 'readme_app' do
+  action [:enable, :start]
+end

--- a/chef/cookbooks/metasploitable/recipes/ruby23.rb
+++ b/chef/cookbooks/metasploitable/recipes/ruby23.rb
@@ -1,0 +1,15 @@
+#
+# Cookbook:: metasploitable
+# Recipe:: ruby23
+#
+# Copyright:: 2017, Rapid7, All Rights Reserved.
+#
+#
+
+execute 'apt-get update' do
+  command 'apt-get update'
+end
+
+package 'ruby2.3'
+package 'ruby2.3-dev'
+package 'bundler'

--- a/chef/cookbooks/metasploitable/recipes/ruby23.rb
+++ b/chef/cookbooks/metasploitable/recipes/ruby23.rb
@@ -6,6 +6,10 @@
 #
 #
 
+apt_repository 'rvm' do
+  uri 'ppa:brightbox/ruby-ng'
+end
+
 execute 'apt-get update' do
   command 'apt-get update'
 end

--- a/chef/cookbooks/metasploitable/recipes/sinatra.rb
+++ b/chef/cookbooks/metasploitable/recipes/sinatra.rb
@@ -7,14 +7,7 @@
 #
 
 include_recipe 'metasploitable::sinatra'
-
-apt_repository 'rvm' do
-  uri 'ppa:brightbox/ruby-ng'
-end
-
-package 'ruby2.3'
-
-package 'bundler'
+include_recipe 'metasploitable::ruby23'
 
 directory '/opt/sinatra' do
   mode '0777'


### PR DESCRIPTION
This PR adds a vulnerable Rails application. It contains information on the Metasploitable instance of your choice. It is vulnerable to RCE using the render function in ActionPack.

Verification
- [x] Build the VM using `vagrant up trusty`
- [ ] Verify you can access the webserver at http://<IP>:3000/readme
- [ ] Load up `msfconsole` and `use exploit/multi/http/rails_actionpack_inline_exec`
- [ ] Set the options: `set TARGETURI /readme` `set TARGETPARAM os` and any other options needed for RHOST and payloads
- [ ] Run the module. You should get a shell.