### PR TITLE
Fix Archlinux detection

### DIFF
--- a/build_win2008.sh
+++ b/build_win2008.sh
@@ -42,7 +42,7 @@ if [ $(uname) = "Darwin" ]; then
     vagrant_exact_match=false
 elif [ $(uname) = "Linux" ]; then
     vagrant_exact_match=false
-    if cat /etc/*-release | grep -q 'DISTRIB_ID=Arch'; then
+    if (cat /etc/*-release | grep -q 'DISTRIB_ID=Arch')|(cat /etc/os-release | grep -q 'ID=arch'); then
         packer_bin="packer-io"
     fi
 fi


### PR DESCRIPTION
Archlinux doesn't seem to use the option "DISTRIB_ID" in /etc/os-release anymore.
https://www.freedesktop.org/software/systemd/man/os-release.html lists no option as mandatory and ID seems like it could be stable.

Alternatively, /etc/arch-release might be around for a while and could be checked.