### PR TITLE
Corrected tomcat version

### DIFF
--- a/scripts/chocolatey_installs/tomcat.bat
+++ b/scripts/chocolatey_installs/tomcat.bat
@@ -1,4 +1,4 @@
 chocolatey feature enable -n=allowGlobalConfirmation
-choco install tomcat
+choco install tomcat --version 8.0.33
 chocolatey feature disable -n=allowGlobalConfirmation
 exit


### PR DESCRIPTION
This PR mentions the version of tomcat to be downloaded for smooth build. 

A general `choco install tomcat` downloads Apache Tomcat 8.5.12 by default. The service is installed with the name `Apache Tomcat 8.5 Tomcat8`.

![image](https://cloud.githubusercontent.com/assets/12944530/26274979/14bf1964-3d74-11e7-85e4-2a6fb7808b59.png)

But as per the [command provided in file `setup_apache_struts.bat`](https://github.com/rapid7/metasploitable3/blob/master/scripts/installs/setup_apache_struts.bat#L6), it starts the service: `net start "Apache Tomcat 8.0 Tomcat8"`

On using the version of tomcat, we could install the correct version.
**Checkout the next screenshots for more details:**

Error message during installation using `choco install tomcat`
![image](https://cloud.githubusercontent.com/assets/12944530/26275040/7d86c0b8-3d75-11e7-9501-202eb05b8829.png)

**After installation of `choco install tomcat --version 8.0.33`**
![image](https://cloud.githubusercontent.com/assets/12944530/26275016/c53e369e-3d74-11e7-9d77-d8d5ae6f0d94.png)

Executing command `sc config Tomcat8 start= auto`
![image](https://cloud.githubusercontent.com/assets/12944530/26275022/ef222a38-3d74-11e7-8758-03e5c8c1480c.png)

Executing command `net start "Apache Tomcat 8.0 Tomcat8"`
![image](https://cloud.githubusercontent.com/assets/12944530/26275029/106ee596-3d75-11e7-81fc-8359b38a9beb.png)


( Linked with errors #64, #74 and #141 )