### PR TITLE
Added dotNet4.5 and Windows Management Framework 5

### DIFF
--- a/scripts/chocolatey_installs/dotnet.bat
+++ b/scripts/chocolatey_installs/dotnet.bat
@@ -1,0 +1,4 @@
+chocolatey feature enable -n=allowGlobalConfirmation
+choco install dotnet4.5
+chocolatey feature disable -n=allowGlobalConfirmation
+exit

--- a/scripts/chocolatey_installs/wmf.bat
+++ b/scripts/chocolatey_installs/wmf.bat
@@ -1,0 +1,4 @@
+chocolatey feature enable -n=allowGlobalConfirmation
+choco install powershell
+chocolatey feature disable -n=allowGlobalConfirmation
+exit

--- a/windows_2008_r2.json
+++ b/windows_2008_r2.json
@@ -148,7 +148,9 @@
         "scripts/configs/create_users.bat",
         "scripts/installs/setup_iis.bat",
         "scripts/installs/setup_ftp_site.bat",
-        "scripts/chocolatey_installs/java.bat"
+        "scripts/chocolatey_installs/java.bat",
+        "scripts/chocolatey_installs/dotnet.bat",
+        "scripts/chocolatey_installs/wmf.bat"
       ]
     },
     {


### PR DESCRIPTION
This PR is made for the Inspec tests to work ( PR #160 ). **It should be merged before merging inspec tests.**
Previously, dotNet 4 was installed in metasploitable 3. But for Inspec to detect the OS, it requires atleast dotNet 4.5 and Windows Management Framework 5 (powershell v5).
