### PR TITLE
Moved devkit to RubyDevKit

### DIFF
--- a/scripts/installs/install_devkit.bat
+++ b/scripts/installs/install_devkit.bat
@@ -1,8 +1,7 @@
-mkdir "C:\Program Files\Rails_Server"
-mkdir "C:\Program Files\Rails_Server\devkit"
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe', 'C:\Program Files\Rails_Server\devkit\devkit.exe')" <NUL
-cmd /c ""C:\Program Files\7-Zip\7z.exe" x "C:\Program Files\Rails_Server\devkit\devkit.exe" -o"C:\Program Files\Rails_Server\devkit\""
-copy /Y C:\Vagrant\resources\Rails_Server\devkit\dk.rb "C:\Program Files\Rails_Server\devkit"
-C:\tools\ruby23\bin\ruby.exe "C:\Program Files\Rails_Server\devkit\dk.rb" init
-C:\tools\ruby23\bin\ruby.exe "C:\Program Files\Rails_Server\devkit\dk.rb" install
-"C:\Program Files\Rails_Server\devkit\devkitvars.bat"
+mkdir "C:\RubyDevKit"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe', 'C:\RubyDevKit\devkit.exe')" <NUL
+cmd /c ""C:\Program Files\7-Zip\7z.exe" x "C:\RubyDevKit\devkit.exe" -o"C:\RubyDevKit\""
+copy /Y C:\Vagrant\resources\Rails_Server\devkit\dk.rb "C:\RubyDevKit"
+C:\tools\ruby23\bin\ruby.exe "C:\RubyDevKit\dk.rb" init
+C:\tools\ruby23\bin\ruby.exe "C:\RubyDevKit\dk.rb" install
+"C:\RubyDevKit\devkitvars.bat"

--- a/windows_2008_r2.json
+++ b/windows_2008_r2.json
@@ -185,6 +185,9 @@
       "remote_path": "C:/Windows/Temp/script.bat",
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
+        "scripts/installs/install_rails_server.bat",
+        "scripts/installs/setup_rails_server.bat",
+        "scripts/installs/install_rails_service.bat",
         "scripts/installs/setup_webdav.bat",
         "scripts/installs/setup_mysql.bat",
         "scripts/installs/install_manageengine.bat",


### PR DESCRIPTION
This PR resolves #179 and #180 - issue with ruby on rails application.

**Issue in detail:**
- Devkit installation created the folder `C:\Program Files\Rails_Server` ([Code](https://github.com/rapid7/metasploitable3/blob/master/scripts/installs/install_devkit.bat#L1))
- [Ruby on Rails initialization](https://github.com/rapid7/metasploitable3/blob/master/scripts/installs/install_rails_server.bat#L30) fails as the folder already exists

**Steps taken to resolve:**
- Moved Ruby DevKit installation to `C:\RubyDevKit` folder

**Verification:**
- [x] Build the VM using packer : `packer build --only=virtualbox-iso windows_2008_r2.json`. It should complete successfully.
- [x] Add the box file : `vagrant box add metasploitable3 windows_2008_r2_virtualbox.box`
- [x] Start the box : `vagrant up`
- [x] *Do a nmap scan from attacker machine* to see if port 3000 is open