### PR TITLE
Adding arch deviation support and packer var for windows.

### DIFF
--- a/build_win2008.ps1
+++ b/build_win2008.ps1
@@ -4,6 +4,7 @@ $virtualBoxMinVersion = "5.1.10"
 $packerMinVersion = "0.10.0"
 $vagrantMinVersion = "1.9.0"
 $vagrantreloadMinVersion = "0.0.1"
+$packer = "packer"
 
 function CompareVersions ($actualVersion, $expectedVersion, $exactMatch = $False) {
     If ($exactMatch) {
@@ -48,7 +49,7 @@ If (CompareVersions -actualVersion $vboxVersion -expectedVersion $virtualBoxMinV
     exit
 }
 
-$packerVersion = cmd.exe /c "packer" -v
+$packerVersion = cmd.exe /c $packer -v
 
 If (CompareVersions -actualVersion $packerVersion -expectedVersion $packerMinVersion) {
     Write-Host "Compatible version of packer found."
@@ -99,7 +100,7 @@ If ($(Test-Path "windows_2008_r2_virtualbox.box") -eq $True) {
     Write-Host "It looks like the Vagrant box already exists. Skipping the Packer build."
 } else {
     Write-Host "Building the Vagrant box..."
-    cmd.exe /c packer build --only=virtualbox-iso windows_2008_r2.json
+    cmd.exe /c $packer build --only=virtualbox-iso windows_2008_r2.json
 
     if($?) {
         Write-Host "Box successfully built by Packer."

--- a/build_win2008.sh
+++ b/build_win2008.sh
@@ -42,7 +42,7 @@ if [ $(uname) = "Darwin" ]; then
     vagrant_exact_match=false
 elif [ $(uname) = "Linux" ]; then
     vagrant_exact_match=false
-    if (cat /etc/*-release | grep -q 'DISTRIB_ID=Arch')|(cat /etc/os-release | grep -q 'ID=arch'); then
+    if (cat /etc/*-release | grep -q 'DISTRIB_ID=Arch')|(cat /etc/os-release | grep -Pq 'ID=(arch|"antergos")'); then
         packer_bin="packer-io"
     fi
 fi


### PR DESCRIPTION
For build_win2008.ps1:
I made it to when you call packer it is a variable. The reason why I did that is because when you are installing packer on windows (at least for me) it just downloads the executable and you can put it anywhere. It isn't even called packer like how it is in your script (it is packer.exe), but I left it as packer in case of any formalities. So if you are on windows now you can just change the variable to whatever the location and name of your packer install is and it will get called in the script properly.
For  build_win2008.sh:
I just added antergos support by add the grep to do perl regex as well and the '|' means or (like normal) and that "antergos" is the id it is looking for. Currently works for antergos 17.9-ISO-Rolling.