### PR TITLE
suppress non-zero exit for glassfish start

### DIFF
--- a/scripts/installs/start_glassfish_service.bat
+++ b/scripts/installs/start_glassfish_service.bat
@@ -1,2 +1,3 @@
 powershell -command "Start-Sleep -s 15"
 net start "domain1"
+exit 0


### PR DESCRIPTION
When requesting glassfish to start in vmware fusion 10 packer get
a non-zero exit code when service is already starting.  This looks
to be valid to simply ignore.

Testing requires a valid VMware Fusion 10 installation, virtualbox and VMware workstation/player should also be tested.
`packer build --only=vmware-iso windows_2008_r2.json`