### PR TITLE
Fix for "Could not create SSL/TLS secure channel".

### DIFF
--- a/scripts/installs/install_openjdk6.bat
+++ b/scripts/installs/install_openjdk6.bat
@@ -1,2 +1,2 @@
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://github.com/downloads/alexkasko/openjdk-unofficial-builds/openjdk-1.6.0-unofficial-b27-windows-amd64.zip', 'C:\Windows\Temp\openjdk-1.6.0-unofficial-b27-windows-amd64.zip')" <NUL
+powershell -Command "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://github.com/downloads/alexkasko/openjdk-unofficial-builds/openjdk-1.6.0-unofficial-b27-windows-amd64.zip', 'C:\Windows\Temp\openjdk-1.6.0-unofficial-b27-windows-amd64.zip')" <NUL
 cmd /c ""C:\Program Files\7-Zip\7z.exe" x "C:\Windows\Temp\openjdk-1.6.0-unofficial-b27-windows-amd64.zip" -oC:\openjdk6"


### PR DESCRIPTION
Hello,

Proposed file change is potential fix for ""Could not create SSL/TLS secure channel"" with ""scripts/installs/install_openjdk6.bat"".
Discussed there: https://github.com/rapid7/metasploitable3/issues/219

Github.com [removed support for TLSv1/TLSv1.1](https://blog.github.com/2018-02-23-weak-cryptographic-standards-removed/); PowerShell's default choice is TLSv1. By proposed changes - we will force PowerShell to use TLSv1.2.

- [x] clean installation of metasploitable3 by other users.
- - - -
Also, I am not sure that it is a fix for entire https://github.com/rapid7/metasploitable3/issues/219 .

In addition, there (scripts/installs) are some other scripts with downloading files by PowerShell. Where "download.microsoft.com" in use; Not sure if they are planned to drop support for TLSv1. Maybe it may be good to tweak such places too.

Thanks!