### PR TITLE
use chocolatey version 0.10.8 until install is fixed

### DIFF
--- a/packer/templates/windows_2008_r2.json
+++ b/packer/templates/windows_2008_r2.json
@@ -133,7 +133,7 @@
     {
       "type":"powershell",
       "inline": [
-        "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
+        "$env:chocolateyVersion = '0.10.8'; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
       ],
       "pause_before": "60s"
     },


### PR DESCRIPTION
Locks version of chocolatey to fix failure to install when latest 0.10.9 is pulled down.