### PR TITLE
Hardcoded chef-client version to 13.8.5

### DIFF
--- a/packer/templates/ubuntu_1404.json
+++ b/packer/templates/ubuntu_1404.json
@@ -87,6 +87,7 @@
   "provisioners": [
     {
       "type": "chef-solo",
+      "version": "13.8.5",
       "cookbook_paths": [
         "{{template_dir}}/../../chef/cookbooks"
       ],


### PR DESCRIPTION
It was found that the latest version of chef-client (v14.0.190 released on 2018-04-03) had some issues with installing mysql service. I have hardcoded the version to be used : 13.8.5

My Packer version: v1.2.2

**Steps to test:**
- [x] `packer build --only=virtualbox-iso packer/templates/ubuntu_1404.json`

(Merging this will fixes issues #262 and #263)