### PR TITLE
Added support for building and running on qemu/kvm via libvirt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 .vagrant/
 packer_cache/
 packer/builds/
+resources/drivers/
+*.vfd
 *.exe
 *.msi
 *.msu
 *.DS_Store
-resources/manageengine/setup.log
-windows_2008_r2_virtualbox.box
-windows_2008_r2_vmware.box
+*.box
+*.iso
+*.vfd

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Requirements:
 * [Packer](https://www.packer.io/intro/getting-started/install.html)
 * [Vagrant](https://www.vagrantup.com/docs/installation/)
 * [Vagrant Reload Plugin](https://github.com/aidanns/vagrant-reload#installation)
-* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or libvirt/qemu-kvm
 * Internet connection
 
 To build automatically:
 
-1. On Linux/OSX run `./build.sh windows2008` to build the Windows box or `./build.sh ubuntu1404` to build the Linux box. On Windows, run `build_win2008.ps1` in a powershell terminal to build the Windows box.
+1. On Linux/OSX run `./build.sh windows2008` to build the Windows box or `./build.sh ubuntu1404` to build the Linux box. If /tmp is small, use `TMPDIR=/var/tmp ./build.sh ...` to store temporary packer disk images under /var/tmp. On Windows, run `build_win2008.ps1` in a powershell terminal to build the Windows box.
 2. If the command completes successfully, run `vagrant up`.
 3. When this process completes, you should be able to open the VM within VirtualBox and login. The default credentials are U: `vagrant` and P: `vagrant`.
 

--- a/build.sh
+++ b/build.sh
@@ -144,7 +144,7 @@ for provider in virtualbox-iso qemu; do
     search_string="$os_full"_"$provider"_"$box_version"
     mkdir -p "$packer_build_path"
     if ls $packer_build_path | grep -q "$search_string"; then
-	echo "It looks like the $provider vagrant box already exists. Skipping the build." 
+	echo "It looks like the $provider vagrant box already exists. Skipping the build."
     elif [ "$build_qemu" = true ] || [ "$build_virtualbox" = true ]; then
 	echo "Building the Vagrant boxes..."
 	if $packer_bin build packer/templates/$os_full.json; then

--- a/packer/answer_files/2008_r2/Autounattend.xml
+++ b/packer/answer_files/2008_r2/Autounattend.xml
@@ -2,6 +2,13 @@
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <servicing/>
     <settings pass="windowsPE">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DriverPaths>
+                <PathAndCredentials wcm:keyValue="1" wcm:action="add">
+                    <Path>A:\</Path>
+                </PathAndCredentials>
+	    </DriverPaths>
+	</component>
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DiskConfiguration>
                 <Disk wcm:action="add">

--- a/packer/scripts/virtio-win-drivers.sh
+++ b/packer/scripts/virtio-win-drivers.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# URI for downloading the latest WHQL'd Virtio drivers
+virtio_uri="https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win_amd64.vfd"
+
+# le flag
+have_tools=true
+
+# Tools messages
+need_wget () {
+    echo "Could not find wget, which is needed to download the virtio disk."
+    echo "To install -"
+    echo ""
+    echo "Fedora: sudo dnf install wget"
+    echo "Debian/Ubuntu: sudo apt install wget"
+}
+
+need_7z () {
+    echo "Could not find 7z, which is required for extracting the virtio driver disk."
+    echo "To install -"
+    echo ""
+    echo "Fedora: sudo dnf install p7zip p7zip-plugins"
+    echo "Debian/Ubuntu: sudo apt install p7zip-full"
+}
+
+# Check for needed tools
+if [ ! -x /usr/bin/wget ]; then
+    need_wget
+    have_tools=false
+fi
+
+if [ ! -x /usr/bin/7z ]; then
+    need_7z
+    have_tools=false
+fi
+
+if [ "$have_tools" = true ]; then
+    if [ -f ".virtio-stable.vfd" ]; then
+	echo ".virtio-stable.vfd already exists, skipping download."
+    else
+	echo "Downloading and extracting virtio stable drivers."
+	wget -c "${virtio_uri}" -O .virtio-stable.vfd && 7z x -oresources/drivers/virtio .virtio-stable.vfd txtsetup.oem disk1 amd64/Win2008
+    fi 
+fi

--- a/packer/scripts/virtio-win-drivers.sh
+++ b/packer/scripts/virtio-win-drivers.sh
@@ -40,5 +40,5 @@ if [ "$have_tools" = true ]; then
     else
 	echo "Downloading and extracting virtio stable drivers."
 	wget -c "${virtio_uri}" -O .virtio-stable.vfd && 7z x -oresources/drivers/virtio .virtio-stable.vfd txtsetup.oem disk1 amd64/Win2008
-    fi 
+    fi
 fi

--- a/packer/templates/ubuntu_1404.json
+++ b/packer/templates/ubuntu_1404.json
@@ -154,7 +154,6 @@
     {
       "type": "vagrant",
       "keep_input_artifact": false,
-	    exit 1
       "output": "{{template_dir}}/../builds/ubuntu_1404_{{.Provider}}_{{user `box_version`}}.box"
     }
   ],

--- a/packer/templates/ubuntu_1404.json
+++ b/packer/templates/ubuntu_1404.json
@@ -82,6 +82,41 @@
           "2"
         ]
       ]
+    },
+    {
+      "type": "qemu",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": false,
+      "http_directory" : "{{template_dir}}/../http",
+      "http_port_min" : 9001,
+      "http_port_max" : 9001,
+      "boot_command": [
+        "<esc><wait>",
+        "<esc><wait>",
+        "<enter><wait>",
+        "/install/vmlinuz",
+        " auto=true",
+        " priority=critical",
+        " initrd=/install/initrd.gz",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg",
+        " -- ",
+        "<enter>"
+      ],
+      "boot_wait": "20s",
+      "communicator": "ssh",
+      "accelerator": "kvm",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "echo 'packer' | sudo -S shutdown -P now",
+      "disk_size": 40000,
+      "vm_name": "metasploitable3-ub1404",
+      "qemuargs": [
+        ["-m", "4096"],
+        ["-smp", "2"]
+      ]
     }
   ],
   "provisioners": [
@@ -119,6 +154,7 @@
     {
       "type": "vagrant",
       "keep_input_artifact": false,
+	    exit 1
       "output": "{{template_dir}}/../builds/ubuntu_1404_{{.Provider}}_{{user `box_version`}}.box"
     }
   ],

--- a/packer/templates/windows_2008_r2.json
+++ b/packer/templates/windows_2008_r2.json
@@ -94,12 +94,12 @@
           "2"
         ]
       ]
-    },                                                          
-    {                                                        
-      "type": "qemu",                             
-      "iso_url": "{{user `iso_url`}}",                 
-      "iso_checksum_type": "{{user `iso_checksum_type`}}",                       
-      "iso_checksum": "{{user `iso_checksum`}}",                        
+    },
+    {
+      "type": "qemu",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
       "headless": false,
       "boot_wait": "10m",
       "communicator": "ssh",

--- a/packer/templates/windows_2008_r2.json
+++ b/packer/templates/windows_2008_r2.json
@@ -94,6 +94,49 @@
           "2"
         ]
       ]
+    },                                                          
+    {                                                        
+      "type": "qemu",                             
+      "iso_url": "{{user `iso_url`}}",                 
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",                       
+      "iso_checksum": "{{user `iso_checksum`}}",                        
+      "headless": false,
+      "boot_wait": "10m",
+      "communicator": "ssh",
+      "accelerator": "kvm",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 61440,
+      "format": "qcow2",
+      "vm_name": "metasploitable3-win2k8",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "{{user `scripts_dir`}}/configs/microsoft-updates.bat",
+        "{{user `scripts_dir`}}/configs/win-updates.ps1",
+        "{{user `scripts_dir`}}/installs/openssh.ps1",
+        "{{user `scripts_dir`}}/installs/install_dotnet45.ps1",
+        "{{user `scripts_dir`}}/installs/install_wmf.ps1",
+        "{{user `resources_dir`}}/certs/oracle-cert.cer",
+        "{{user `resources_dir`}}/certs/gdig2.crt",
+        "{{user `resources_dir`}}/certs/comodorsadomainvalidationsecureserverca.crt",
+        "{{user `resources_dir`}}/certs/comodorsacertificationauthority.crt",
+        "{{user `resources_dir`}}/certs/addtrust_external_ca.cer",
+        "{{user `resources_dir`}}/certs/baltimore_ca.cer",
+        "{{user `resources_dir`}}/certs/digicert.cer",
+        "{{user `resources_dir`}}/certs/equifax.cer",
+        "{{user `resources_dir`}}/certs/globalsign.cer",
+        "{{user `resources_dir`}}/certs/gte_cybertrust.cer",
+        "{{user `resources_dir`}}/certs/microsoft_root_2011.cer",
+        "{{user `resources_dir`}}/certs/thawte_primary_root.cer",
+        "{{user `resources_dir`}}/certs/utn-userfirst.cer",
+        "./resources/drivers/virtio/*"
+      ],
+      "qemuargs": [
+        ["-m", "4096"],
+        ["-smp", "2"]
+      ]
     }
   ],
 "provisioners": [


### PR DESCRIPTION
Reopened this pull request as the previous one was closed when I rebased.

I have implemented a script to pull the virtio drivers down as needed rather than checking them into the repo, as requested in #232 - I've also rebased against current master and reworked some portions of the build script to keep it DRY when dealing with multiple providers.

Other than those changes, these changes are the same as in #232 