### PR TITLE
updates for qemu as provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Requirements:
 ### To build manually:
 
 1. Clone this repo and navigate to the main directory.
-2. Build the base VM image by running `packer build --only=<provider>-iso ./packer/templates/windows_2008_r2.json` where `<provider>` is your preferred virtualization platform. Currently `virtualbox`, `libvirt`, and `vmware` providers are supported. This will take a while the first time you run it since it has to download the OS installation ISO.
-3. After the base Vagrant box is created you need to add it to your Vagrant environment. This can be done with the command `vagrant box add packer/builds/windows_2008_r2_<provider>_0.1.0.box --name=metasploitable3-win2k8`.
+2. Build the base VM image by running `packer build --only=<provider> ./packer/templates/windows_2008_r2.json` where `<provider>` is your preferred virtualization platform. Currently `virtualbox-iso`, `qemu`, and `vmware-iso` providers are supported. This will take a while the first time you run it since it has to download the OS installation ISO.
+3. After the base Vagrant box is created you need to add it to your Vagrant environment. This can be done with the command `vagrant box add packer/builds/windows_2008_r2_*_0.1.0.box --name=metasploitable3-win2k8`.
 4. Use `vagrant plugin install vagrant-reload` to install the reload vagrant provisioner if you haven't already.
 5. To start the VM, run the command `vagrant up win2k8`. This will start up the VM and run all of the installation and configuration scripts necessary to set everything up. This takes about 10 minutes.
 6. Once this process completes, you can open up the VM within VirtualBox and login. The default credentials are U: vagrant and P: vagrant.

--- a/build.sh
+++ b/build.sh
@@ -110,7 +110,7 @@ if [ $(uname) = "Linux" ]; then
   if compare_versions $(vagrant plugin list | grep 'vagrant-libvirt' | cut -d' ' -f2 | tr -d '(' | tr -d ')' | tr -d ',') $min_vagrantlibvirt_ver false; then
       echo 'Compatible version of vagrant-libvirt plugin was found.'
       echo 'KVM image will be built.'
-      providers="libvirt $providers"
+      providers="qemu $providers"
       echo 'Fetching virtio drivers required for build'
       ./packer/scripts/virtio-win-drivers.sh
   else
@@ -145,7 +145,11 @@ for provider in $providers; do
       echo "It looks like the $provider vagrant box already exists. Skipping the build."
     fi
       echo "Building the Vagrant box for $provider..."
-      if $packer_bin build -only $provider-iso packer/templates/$os_full.json; then
+      packer_provider="$provider-iso"
+      if [ $provider = "qemu" ]; then
+        packer_provider=$provider
+      fi
+      if $packer_bin build -only $packer_provider packer/templates/$os_full.json; then
           echo "Boxes successfully built by Packer."
       else
           echo "Error building the Vagrant boxes using Packer. Please check the output above for any error messages."


### PR DESCRIPTION
Fix #329, update `build.sh` to request the correct provider from the template for `libvirt` compatible systems.