### PR TITLE
remove carriage returns from service config files

### DIFF
--- a/chef/cookbooks/metasploitable/recipes/knockd.rb
+++ b/chef/cookbooks/metasploitable/recipes/knockd.rb
@@ -18,6 +18,10 @@ cookbook_file '/etc/default/knockd' do
   mode '0600'
 end
 
+execute 'remove_carriage_returns' do
+    command "sed -i -e 's/\r//g' /etc/default/knockd"
+end
+
 service 'knockd' do
   action [:enable, :start]
 end

--- a/chef/cookbooks/metasploitable/recipes/proftpd.rb
+++ b/chef/cookbooks/metasploitable/recipes/proftpd.rb
@@ -40,6 +40,11 @@ cookbook_file '/etc/init.d/proftpd' do
   mode '760'
 end
 
+execute 'remove_carriage_returns' do
+  command "sed -i -e 's/\r//g' /etc/init.d/proftpd"
+end
+
+
 # Setup the IP Renewer
 cookbook_file '/opt/proftpd/proftpd_ip_renewer.rb' do
   source 'proftpd/proftpd_ip_renewer.rb'
@@ -47,6 +52,7 @@ cookbook_file '/opt/proftpd/proftpd_ip_renewer.rb' do
   owner 'root'
   group 'root'
 end
+
 
 cookbook_file '/etc/init/proftpd_ip_renewer.conf' do
   source 'proftpd/proftpd_ip_renewer.conf'

--- a/chef/cookbooks/metasploitable/recipes/unrealircd.rb
+++ b/chef/cookbooks/metasploitable/recipes/unrealircd.rb
@@ -67,11 +67,10 @@ cookbook_file '/etc/init.d/unrealircd' do
   mode '760'
 end
 
-execute 'start unrealircd service' do
-  # This should ideally be a service resource but for some reason chef doesn't start the service properly when it is.
-  command '/etc/init.d/unrealircd start'
+execute 'remove_carriage_returns' do
+    command "sed -i -e 's/\r//g' /etc/init.d/unrealircd"
 end
 
 service 'unrealircd' do
-  action :enable
+  action [:enable, :start]
 end


### PR DESCRIPTION
`cookbook_file` + `source` on Windows copies files over using a windows terminal which adds carriage returns to EOL. Carriage returns on ubuntu prevent service start commands from functioning. Reports "file not found", breaking build.

Therefore, destroy all carriage returns. Wish I knew a more elegant way to do that besides `sed` after each affected file copy.

Closes #326 and friends