### PR TITLE
windows.json, change vmware guest_os_type to match proper vmware os i…

### DIFF
--- a/packer/templates/windows_2008_r2.json
+++ b/packer/templates/windows_2008_r2.json
@@ -12,7 +12,7 @@
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "2h",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "guest_os_type": "winServer2008Standard-64",
+      "guest_os_type": "windows7srv-64",
       "tools_upload_flavor": "windows",
       "disk_size": 61440,
       "floppy_files": [


### PR DESCRIPTION
@Cisco-Talos is using metasploitable3 builds to generate in-house customized exploitable VMs. Along the way, we identified issues with using vmware host environments when changing network adapters to host only. Eventually we tracked this down to the OS type not being set correctly via the vmx file.

Presently importing the generated VM into vmware sets the OS type as Other/Unknown due to the window_200k_r2.json allowing `"guest_os_type": "winServer2008Standard-64",` and not setting `"guest_os_type": "windows7srv-64"`. Per [VmWare OS Identifiers](https://www.vmware.com/support/developer/converter-sdk/conv43_apireference/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html) we should be using "windows7srv-64" to indicate Windows Server 2008 R2 x64 variants.

This resolves issues #164, #212, and #223; and may help or resolve #167 and #323.

This was tested with:
Metasploitable3: git master branch, current
Host OS: ArchLinux 4.19
Packer: v1.3.2
VmWare: Workstation 14
Cmd: `packer build --only=vmware-iso ./packer/templates/windows_2008_r2.json`