### PR TITLE
add explicit TLS 1.2 setting to PS session when downloading RubyDevKit

### DIFF
--- a/scripts/installs/install_devkit.bat
+++ b/scripts/installs/install_devkit.bat
@@ -1,5 +1,5 @@
 mkdir "C:\RubyDevKit"
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe', 'C:\RubyDevKit\devkit.exe')" <NUL
+powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe', 'C:\RubyDevKit\devkit.exe')" <NUL
 cmd /c ""C:\Program Files\7-Zip\7z.exe" x "C:\RubyDevKit\devkit.exe" -o"C:\RubyDevKit\""
 copy /Y C:\Vagrant\resources\Rails_Server\devkit\dk.rb "C:\RubyDevKit"
 C:\tools\ruby23\bin\ruby.exe "C:\RubyDevKit\dk.rb" init


### PR DESCRIPTION
Referencing issue #185 when getting switching to the new https endpoing from http, the powershell command executed when building the win2k8 box using packer will still throw an exception, unless the security protocol for the WebClient is set to TLS 1.2 (as it is now pretty much enforced everywhere. The settings is only good for a single session, so it needs to be pre-pended to every bat file that invokes a web request/download via "powershell.exe  -Command ...".