### PR TITLE
make guest tools last so pre-reqs are in place

### DIFF
--- a/packer/templates/windows_2008_r2.json
+++ b/packer/templates/windows_2008_r2.json
@@ -157,7 +157,6 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "{{user `scripts_dir`}}/configs/update_root_certs.bat",
-        "{{user `scripts_dir`}}/installs/vm-guest-tools.bat",
         "{{user `scripts_dir`}}/configs/vagrant-ssh.bat",
         "{{user `scripts_dir`}}/configs/disable-auto-logon.bat",
         "{{user `scripts_dir`}}/configs/enable-rdp.bat"
@@ -240,7 +239,15 @@
         "{{user `scripts_dir`}}/installs/setup_snmp.bat",
         "{{user `scripts_dir`}}/configs/configure_firewall.bat",
         "{{user `scripts_dir`}}/installs/install_elasticsearch.bat",
-        "{{user `scripts_dir`}}/installs/install_flags.bat",
+        "{{user `scripts_dir`}}/installs/install_flags.bat"
+      ]
+    },
+    {
+      "type": "shell",
+      "remote_path": "/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
+      "scripts": [
+        "{{user `scripts_dir`}}/installs/vm-guest-tools.bat",
         "{{user `scripts_dir`}}/configs/packer_cleanup.bat"
       ]
     },

--- a/scripts/installs/vm-guest-tools.bat
+++ b/scripts/installs/vm-guest-tools.bat
@@ -10,10 +10,6 @@ goto :done
 
 :vmware
 
-if exist "C:\Users\vagrant\windows.iso" (
-    move /Y C:\Users\vagrant\windows.iso C:\Windows\Temp
-)
-
 if not exist "C:\Windows\Temp\windows.iso" (
     powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://softwareupdate.vmware.com/cds/vmw-desktop/ws/12.0.0/2985596/windows/packages/tools-windows.tar', 'C:\Windows\Temp\vmware-tools.tar')" <NUL
     cmd /c ""C:\Program Files\7-Zip\7z.exe" x C:\Windows\Temp\vmware-tools.tar -oC:\Windows\Temp"


### PR DESCRIPTION
fixes #216 

VMware tools requires the vcredist2008 installed and a reboot occur before installation on windows 2008r2.  This moves guest tools to install last just before cleanup.

Thanks to @jschulist for the report and @usmcfiredog for the additional validation that this issue persists.