### PR TITLE
locking sqlite3 install version to 1.3.11

### DIFF
--- a/resources/rails_server/Gemfile
+++ b/resources/rails_server/Gemfile
@@ -4,7 +4,7 @@ source 'http://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.1'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem 'sqlite3', '1.3.11'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 4.0.3'
 # Use Uglifier as compressor for JavaScript assets


### PR DESCRIPTION
The new version of sqlite3 breaks the install process for the windows setup.