### PR TITLE
added | tr -d ',' to resolve the syntax

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -125,7 +125,7 @@ if compare_versions $(vagrant plugin list | grep 'vagrant-vmware' | cut -d' ' -f
   providers="vmware $providers"
 fi
 
-if compare_versions $(vagrant plugin list | grep 'vagrant-reload' | cut -d' ' -f2 | tr -d '(' | tr -d ')') $min_vagrantreload_ver false; then
+if compare_versions $(vagrant plugin list | grep 'vagrant-reload' | cut -d' ' -f2 | tr -d '(' | tr -d ')' | tr -d ',') $min_vagrantreload_ver false; then
     echo 'Compatible version of vagrant-reload plugin was found.'
 else
     echo "Compatible version of vagrant-reload plugin was not found."


### PR DESCRIPTION
There is a syntax error when running the script. Added the fix as stated in issue #339