### PR TITLE
Fix install of elasticsearch on Windows

### DIFF
--- a/scripts/installs/install_elasticsearch.bat
+++ b/scripts/installs/install_elasticsearch.bat
@@ -1,4 +1,4 @@
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://repo1.maven.org/maven2/org/elasticsearch/elasticsearch/1.1.1/elasticsearch-1.1.1.zip', 'C:\Windows\Temp\elasticsearch-1.1.1.zip')" <NUL
+powershell -Command "[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true} ; (New-Object System.Net.WebClient).DownloadFile('http://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.1.1.zip', 'C:\Windows\Temp\elasticsearch-1.1.1.zip')" <NUL
 cmd /c ""C:\Program Files\7-Zip\7z.exe" x "C:\Windows\Temp\elasticsearch-1.1.1.zip" -o"C:\Program Files\""
 cmd /c ""C:\Program Files\elasticsearch-1.1.1\bin\service.bat" install"
 sc config "elasticsearch-service-x64" start= auto


### PR DESCRIPTION
The install is failing as the .zip download was not working.  Updated link to elaticsearch.co, changed it from http to https, and updated the script to ignore cert errors.  All changes were required to make it work (for me at least).