### PR TITLE
Fix Powershell SSL/TLS error for chocolatey download

### DIFF
--- a/packer/templates/windows_2008_r2.json
+++ b/packer/templates/windows_2008_r2.json
@@ -185,7 +185,7 @@
     {
       "type": "powershell",
       "inline": [
-        "$env:chocolateyVersion = '0.10.8'; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
+        "$env:chocolateyVersion = '0.10.8'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
       ],
       "pause_before": "60s"
     },

--- a/scripts/installs/install_chocolatey.ps1
+++ b/scripts/installs/install_chocolatey.ps1
@@ -1,5 +1,6 @@
 $ChocoInstallPath = "$env:SystemDrive\ProgramData\Chocolatey\bin"
 
 if (!(Test-Path $ChocoInstallPath)) {
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
   iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
 }


### PR DESCRIPTION
When building the Windows 2008 Metasploitable3 machine, the installation always halts because it fails to download Chocolatey with an SSL/TLS error. Apparently, Powershell defaults to TLSv1.0 which isn't supported by the Chcolatey web server.
This fix instructs the net.webclient to use TLSv1.2, instead.