### PR TITLE
Add ports for apache continuum and its wrapper to iptables

### DIFF
--- a/chef/cookbooks/metasploitable/attributes/default.rb
+++ b/chef/cookbooks/metasploitable/attributes/default.rb
@@ -18,5 +18,7 @@ default[:metasploitable][:ports] = { :cups => 631,
                                      :chatbot_nodejs => 3000,
                                      :readme_app => 3500,
                                      :sinatra => 8181,
-                                     :samba => 445
+                                     :samba => 445,
+                                     :wrapper => 32000,
+                                     :continuum => 8080
 }


### PR DESCRIPTION
This fixes the apache continuum setup so that the JVM can connect to the wrapper which runs on port 32000 at localhost
Also adds the actual jetty webserver port 8080 to the iptables so it can be reached from other hosts in the network

This allows usage of the Apache Continuum exploit module as well - https://www.rapid7.com/db/modules/exploit/linux/http/apache_continuum_cmd_exec

Attached images below for new iptables setup, module execution as well as wrapper logs for apache continuum

![image](https://user-images.githubusercontent.com/1071059/79091162-3f217380-7d1a-11ea-9edb-3c292b62a887.png)

![image](https://user-images.githubusercontent.com/1071059/79091201-68da9a80-7d1a-11ea-9980-ee7f9b0c3859.png)

![image](https://user-images.githubusercontent.com/1071059/79091223-7f80f180-7d1a-11ea-88ac-68c18fb4646e.png)

``