### PR TITLE
lock the java package

### DIFF
--- a/scripts/chocolatey_installs/java.bat
+++ b/scripts/chocolatey_installs/java.bat
@@ -1,4 +1,4 @@
 chocolatey feature enable -n=allowGlobalConfirmation
-choco install javaruntime-platformspecific
+choco install jre8 --version 8.0.251
 chocolatey feature disable -n=allowGlobalConfirmation
 exit


### PR DESCRIPTION
The many services that rely on java need to have better limits.

By installing a specific compatible java version early the build
can eliminate churn and provide more consistent enviornments.