### PR TITLE
Allow ICMP protocol for linux machine (merges #394)

### DIFF
--- a/chef/cookbooks/metasploitable/recipes/iptables.rb
+++ b/chef/cookbooks/metasploitable/recipes/iptables.rb
@@ -14,6 +14,10 @@ iptables_rule '01_ssh' do
   lines "-A INPUT -p tcp --dport 22 -j ACCEPT"
 end
 
+iptables_rule '01_icmp' do
+  lines "-A INPUT -p icmp -j ACCEPT"
+end
+
 iptables_rule '999_drop_all' do
   lines '-A INPUT -j DROP'
 end


### PR DESCRIPTION
Required for setup_linux_share.bat provisioning script on the windows
machine. Fix #393

Merges #394 