### PR TITLE
only fetch apache continuum if missing

### DIFF
--- a/chef/cookbooks/metasploitable/recipes/apache_continuum.rb
+++ b/chef/cookbooks/metasploitable/recipes/apache_continuum.rb
@@ -16,6 +16,7 @@ end
 remote_file "#{Chef::Config[:file_cache_path]}/#{node[:apache_continuum][:tar]}" do
   source "#{node[:apache_continuum][:download_url]}/#{node[:apache_continuum][:tar]}"
   mode '0644'
+  action :create_if_missing
 end
 
 execute "extract apache continum" do


### PR DESCRIPTION
shaves a good 30+ seconds off of provisioning