### PR TITLE
allow all loopback traffic

### DIFF
--- a/chef/cookbooks/metasploitable/recipes/iptables.rb
+++ b/chef/cookbooks/metasploitable/recipes/iptables.rb
@@ -10,6 +10,14 @@ iptables_rule '00_established' do
   lines '-A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT'
 end
 
+iptables_rule '00_lo_allow_in' do
+  lines '-I INPUT -i lo -j ACCEPT'
+end
+
+iptables_rule '00_lo_allow_out' do
+  lines '-I OUTPUT -o lo -j ACCEPT'
+end
+
 iptables_rule '01_ssh' do
   lines "-A INPUT -p tcp --dport 22 -j ACCEPT"
 end
@@ -17,6 +25,3 @@ end
 iptables_rule '999_drop_all' do
   lines '-A INPUT -j DROP'
 end
-
-
-


### PR DESCRIPTION
This is necessary because one of the last firewall rules otherwise drops all all incoming traffic for all interfaces. Prevents apache continuum's wrapper from connecting to the jvm or something like that, see https://github.com/rapid7/metasploitable3/pull/458#issuecomment-702942817

Also closes #458 