### PR TITLE
update docs for using vagrant to develop ub1404

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,25 +65,39 @@ https://www.youtube.com/playlist?list=PLZOToVAK85MpnjpcVtNMwmCxMZRFaY6mT
 
 ### ub1404 Development and Modification
 
-Using Vagrant and a lightweight Ubuntu 14.04 vagrant cloud box image, you can quickly set up and customize ub1404 Metasploitable3 for development or customization.
-To do so, install Vagrant and a hypervisor such as VirtualBox. Then, visit the `bento/ubuntu-14.04` page and find a version that supports
-your hypervisor. For instance, version `v201808.24.0` is compatible with VirtualBox.
+Using Vagrant and a lightweight Ubuntu 14.04 vagrant cloud box image, you can
+quickly set up and customize ub1404 Metasploitable3 for development or
+customization. To do so, install Vagrant and a hypervisor such as VirtualBox,
+VMWare, or libvirt.
 
-Install the vagrant virtualbox vbguest plugin:
+Install the relevant provider plugin:
 
+    # virtualbox
     vagrant plugin install vagrant-vbguest
-    
-Then, navigate to the `/chef/dev/ub1404` directory in this repository. Examine the Vagrantfile there. Metasploitable ub1404 uses the vagrant `chef-solo` provisioner.
-To this Vagrantfile, add the metasploitable chef recipes that you desire -- you can browse them in the `/chef/cookbooks/metasploitable` folder. Or, 
-add or edit your own cookbook and/or recipes there.
 
-From the `/chef/dev/ub1404` directory, you can run `vagrant up` to get a development virtual ub1404 instance. After the initial `up` build and provision, 
-when you edit the chef runlist or when you edit a chef recipe, run `vagrant provision` from the same directory. For faster development, you can comment-out 
-recipes that you do not need to rerun -- but even if they are all enabled, vagrant provisioning should not take longer one or two minutes. 
-Chef aims to be idempotent, so you can rerun this command often.
+    # libvirt
+    vagrant plugin install vagrant-libvirt
 
-Consider taking a snapshot (e.g., `vagrant snapshot new fresh`) before modifying recipes, so that you can always return to an initial state (`vagrant restore fresh`).
-If you want a _totally_ fresh snapshot, you can do the initialization with `vagrant up --no-provision`, then take a snapshot, followed by `vagrant provision`.
+Then, navigate to the [chef/dev/ub1404](chef/dev/ub1404) directory in this repository.
+Examine the Vagrantfile there. Select a base box that supports your provider.
+
+Metasploitable ub1404 uses the vagrant `chef-solo` provisioner. Configure the
+chef_solo block in the Vagrantfile with the metasploitable chef recipes that you
+desire -- you can browse them in the [chef/cookbooks/metasploitable](chef/cookbooks/metasploitable)
+folder. Or, add or edit your own cookbook and/or recipes there.
+
+From the [chef/dev/ub1404](chef/dev/ub1404) directory, you can run `vagrant up`
+to get a development virtual ub1404 instance. After the initial `up` build and provision,
+when you edit the chef runlist or when you edit a chef recipe, run
+`vagrant rsync && vagrant provision` from the same directory. For faster
+development, you can comment-out recipes that you do not need to rerun -- but
+even if they are all enabled, vagrant re-provisioning should not take longer than
+one or two minutes. Chef aims to be idempotent, so you can rerun this command often.
+
+Consider taking a snapshot (e.g., `vagrant snapshot save fresh`) before modifying
+recipes, so that you can always return to an initial state (`vagrant restore fresh`).
+If you want a _totally_ fresh snapshot, you can do the initialization with
+`vagrant up --no-provision`, then take a snapshot, followed by `vagrant provision`.
 
 
 ## Vulnerabilities

--- a/chef/dev/ub1404/Vagrantfile
+++ b/chef/dev/ub1404/Vagrantfile
@@ -1,22 +1,20 @@
 # This Vagrantfile can be used to quickly spin up a development instance of ub1404
 
 Vagrant.configure("2") do |config|
-  config.vm.define "dev" do |dev|
-    dev.vm.box = "bento/ubuntu-14.04"
-    dev.vm.box_version = "201808.24.0"
 
-    # alternatively, for libvirt, use the following box:
-    #config.vm.box = "peru/ubuntu-14.04-server-amd64"
-    #config.vm.box_version = "20190901.01"
-    dev.ssh.username = 'vagrant'
-    dev.ssh.password = 'vagrant'
-    dev.vm.network "forwarded_port", guest: 21, host:2121
+  config.vm.define "Metasploitable3-dev"
+  config.vm.box = "bento/ubuntu-14.04"
+  config.vm.box_version = "201808.24.0"
 
-    dev.vm.provider "virtualbox" do |v|
-      v.name = "Metasploitable3-ub1404-dev"
-      v.memory = 2048
-    end
+  config.vm.provider :libvirt do |libvirt, override|
+    override.vm.box = "peru/ubuntu-14.04-server-amd64"
+    override.vm.box_version = "20190901.01"
+    libvirt.memory = 2048
   end
+
+  config.ssh.username = 'vagrant'
+  config.ssh.password = 'vagrant'
+  config.vm.network "forwarded_port", guest: 21, host:2121
 
   # manually rsync recipe changes before re-provisioning. e.g.,
   # `vagrant rsync && vagrant provision`

--- a/chef/dev/ub1404/Vagrantfile
+++ b/chef/dev/ub1404/Vagrantfile
@@ -4,6 +4,10 @@ Vagrant.configure("2") do |config|
   config.vm.define "dev" do |dev|
     dev.vm.box = "bento/ubuntu-14.04"
     dev.vm.box_version = "201808.24.0"
+
+    # alternatively, for libvirt, use the following box:
+    #config.vm.box = "peru/ubuntu-14.04-server-amd64"
+    #config.vm.box_version = "20190901.01"
     dev.ssh.username = 'vagrant'
     dev.ssh.password = 'vagrant'
     dev.vm.network "forwarded_port", guest: 21, host:2121
@@ -13,7 +17,9 @@ Vagrant.configure("2") do |config|
       v.memory = 2048
     end
   end
-  
+
+  # manually rsync recipe changes before re-provisioning. e.g.,
+  # `vagrant rsync && vagrant provision`
   config.vm.provision "chef_solo" do |chef|
     chef.arguments = '--chef-license accept'
     chef.cookbooks_path = [ '../../cookbooks' ]
@@ -41,4 +47,7 @@ Vagrant.configure("2") do |config|
     chef.add_recipe "metasploitable::flags"
     chef.add_recipe "metasploitable::clear_cache"
   end
+
+  # Disable NFS sharing (==> default: Mounting NFS shared folders...)
+  config.vm.synced_folder ".", "/vagrant", type: "nfs", disabled: true
 end


### PR DESCRIPTION
* reference a new box that supports libvirt
* default-disable nfs and instead give instructions for using rsync for 
provisioning with chef-solo