### PR TITLE
only use provisioner for tools

### DIFF
--- a/packer/templates/windows_2008_r2.json
+++ b/packer/templates/windows_2008_r2.json
@@ -13,7 +13,6 @@
       "ssh_wait_timeout": "2h",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "windows7srv-64",
-      "tools_upload_flavor": "windows",
       "disk_size": 61440,
       "floppy_files": [
         "{{user `autounattend`}}",


### PR DESCRIPTION
The packer config for vmware-iso should not attempt tools install.

There is a provisioner script for tools install that detects the
environment and installer to use.