### PR TITLE
vagrant template should not reference `win2k8`

### DIFF
--- a/packer/templates/vagrantfile-windows_2008_r2.template
+++ b/packer/templates/vagrantfile-windows_2008_r2.template
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
     end
 
-    win2k8.vm.provider "libvirt" do |v|
+    config.vm.provider :libvirt do |v|
       v.memory = "2048"
       v.cpus = "2"
       v.video_type = 'qxl'


### PR DESCRIPTION
Fixes #492 

The template file supplied inside the box images does not
have information about the external `name`, just reference config
and the provisioner type.