### PR TITLE
enable tls12 for vagrant key download

### DIFF
--- a/packer/templates/windows_2008_r2.json
+++ b/packer/templates/windows_2008_r2.json
@@ -204,7 +204,6 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "{{user `scripts_dir`}}/configs/update_root_certs.bat",
-        "{{user `scripts_dir`}}/configs/vagrant-ssh.bat",
         "{{user `scripts_dir`}}/configs/disable-auto-logon.bat",
         "{{user `scripts_dir`}}/configs/enable-rdp.bat"
       ]
@@ -222,8 +221,9 @@
     },
     {
       "type": "powershell",
-      "inline": [
-        "$env:chocolateyVersion = '0.10.8'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
+      "scripts": [
+        "./scripts/configs/vagrant-ssh.ps1",
+        "./scripts/installs/chocolatey.ps1"
       ],
       "pause_before": "60s"
     },

--- a/scripts/configs/vagrant-ssh.bat
+++ b/scripts/configs/vagrant-ssh.bat
@@ -1,6 +1,0 @@
-:: vagrant public key
-if exist a:\vagrant.pub (
-  copy a:\vagrant.pub C:\Users\vagrant\.ssh\authorized_keys
-) else (
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub', 'C:\Users\vagrant\.ssh\authorized_keys')" <NUL
-)

--- a/scripts/configs/vagrant-ssh.ps1
+++ b/scripts/configs/vagrant-ssh.ps1
@@ -1,0 +1,56 @@
+function Invoke-CLR4PowerShellCommand {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [ScriptBlock]
+        $ScriptBlock,
+        
+        [Parameter(ValueFromRemainingArguments=$true)]
+        [Alias('Args')]
+        [object[]]
+        $ArgumentList
+    )
+    
+    if ($PSVersionTable.CLRVersion.Major -eq 4) {
+        Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList
+        return
+    }
+
+    $RunActivationConfigPath = $Env:TEMP | Join-Path -ChildPath ([Guid]::NewGuid())
+    New-Item -Path $RunActivationConfigPath -ItemType Container | Out-Null
+@"
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <supportedRuntime version="v4.0"/>
+  </startup>
+</configuration>
+"@ | Set-Content -Path $RunActivationConfigPath\powershell.exe.activation_config -Encoding UTF8
+
+    $EnvVarName = 'COMPLUS_ApplicationMigrationRuntimeActivationConfigPath'
+    $EnvVarOld = [Environment]::GetEnvironmentVariable($EnvVarName)
+    [Environment]::SetEnvironmentVariable($EnvVarName, $RunActivationConfigPath)
+
+    try {
+        & powershell.exe -inputformat text -command $ScriptBlock -args $ArgumentList
+    } finally {
+        [Environment]::SetEnvironmentVariable($EnvVarName, $EnvVarOld)
+        $RunActivationConfigPath | Remove-Item -Recurse
+    }
+
+}
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$isWin8 = wmic os get caption | find /i '" 8 "'
+$isWin2012 = wmic os get caption | find /i '" 2012 "'
+
+# skip wrapping for 8 or 2012?
+if ($isWin8 -or $isWin2012){
+   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub', 'C:\Users\vagrant\.ssh\authorized_keys')
+}else{
+    Invoke-CLR4PowerShellCommand -ScriptBlock {
+       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub', 'C:\Users\vagrant\.ssh\authorized_keys')
+    }
+}

--- a/scripts/installs/chocolatey.ps1
+++ b/scripts/installs/chocolatey.ps1
@@ -1,0 +1,58 @@
+function Invoke-CLR4PowerShellCommand {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [ScriptBlock]
+        $ScriptBlock,
+        
+        [Parameter(ValueFromRemainingArguments=$true)]
+        [Alias('Args')]
+        [object[]]
+        $ArgumentList
+    )
+    
+    if ($PSVersionTable.CLRVersion.Major -eq 4) {
+        Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList
+        return
+    }
+
+    $RunActivationConfigPath = $Env:TEMP | Join-Path -ChildPath ([Guid]::NewGuid())
+    New-Item -Path $RunActivationConfigPath -ItemType Container | Out-Null
+@"
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <supportedRuntime version="v4.0"/>
+  </startup>
+</configuration>
+"@ | Set-Content -Path $RunActivationConfigPath\powershell.exe.activation_config -Encoding UTF8
+
+    $EnvVarName = 'COMPLUS_ApplicationMigrationRuntimeActivationConfigPath'
+    $EnvVarOld = [Environment]::GetEnvironmentVariable($EnvVarName)
+    [Environment]::SetEnvironmentVariable($EnvVarName, $RunActivationConfigPath)
+
+    try {
+        & powershell.exe -inputformat text -command $ScriptBlock -args $ArgumentList
+    } finally {
+        [Environment]::SetEnvironmentVariable($EnvVarName, $EnvVarOld)
+        $RunActivationConfigPath | Remove-Item -Recurse
+    }
+
+}
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$isWin8 = wmic os get caption | find /i '" 8 "'
+$isWin2012 = wmic os get caption | find /i '" 2012 "'
+
+# skip wrapping for 8 or 2012?
+if ($isWin8 -or $isWin2012){
+   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+}else{
+    Invoke-CLR4PowerShellCommand -ScriptBlock {
+       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+    }
+}
+
+# cribbed from https://gist.github.com/jstangroome/882528

--- a/scripts/installs/install_chocolatey.ps1
+++ b/scripts/installs/install_chocolatey.ps1
@@ -1,6 +1,0 @@
-$ChocoInstallPath = "$env:SystemDrive\ProgramData\Chocolatey\bin"
-
-if (!(Test-Path $ChocoInstallPath)) {
-  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-  iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
-}

--- a/scripts/installs/install_netfx40.ps1
+++ b/scripts/installs/install_netfx40.ps1
@@ -1,7 +1,0 @@
-# setup dotnetfx4
-$netfx_url = "https://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe"
-
-Write-Output "Downloading $netfx_url"
-(New-Object System.Net.WebClient).DownloadFile($netfx_url, "C:\Windows\Temp\dotNetFx40_Full_x86_x64.exe")
-Write-Output "Starting Install of dotNetFx40_Full_x86_x64.exe"
-Start-Process "C:\Windows\Temp\dotNetFx40_Full_x86_x64.exe" "/q /norestart" -Wait

--- a/scripts/installs/install_rails_server.bat
+++ b/scripts/installs/install_rails_server.bat
@@ -4,6 +4,7 @@ cmd /C rm .gemrc
 
 copy /Y C:\Vagrant\resources\rails_server\gemrc C:\Users\vagrant\.gemrc
 
+cmd /C "C:\tools\ruby23\bin\gem.cmd install bundler -v '1.17.3' --no-document"
 cmd /C "C:\tools\ruby23\bin\gem.cmd install rails -v '4.1.1' --no-document"
 cmd /C "C:\tools\ruby23\bin\gem.cmd install rake -v '11.3.0' --no-document"
 cmd /C C:\tools\ruby23\bin\gem.cmd install coffee-script-source -v '1.10.0' --no-document

--- a/scripts/installs/setup_rails_server.bat
+++ b/scripts/installs/setup_rails_server.bat
@@ -1,3 +1,4 @@
 copy /Y C:\Vagrant\resources\rails_server\Gemfile "C:\Program Files\Rails_Server"
 cd "C:\Program Files\Rails_Server"
-C:\tools\ruby23\bin\bundler.bat install
+gem install bundler -v '1.17.3' --no-document
+bundle install


### PR DESCRIPTION
Fix #503 

As the internet tries to become more secure new challenges to creating intentionally insecure systems occur.

This uses an old trick from @jstangroome to enable Tls 1.2 usage for powershell downloads.

https://blog.stangroome.com/2011/03/23/executing-individual-powershell-commands-using-net-4/
https://gist.github.com/jstangroome/882528/9e0c55253a261a9c30d0d92cafba57ccbc8e4090

An added bonus in removal of some unused scripts.