### PR TITLE
lock gem version for rails build

### DIFF
--- a/scripts/installs/install_rails_server.bat
+++ b/scripts/installs/install_rails_server.bat
@@ -1,5 +1,5 @@
 cmd /C echo :ssl_verify_mode: 0 > .gemrc
-cmd /C gem update --system
+cmd /C gem update --system 3.2.10
 cmd /C rm .gemrc
 
 copy /Y C:\Vagrant\resources\rails_server\gemrc C:\Users\vagrant\.gemrc


### PR DESCRIPTION
Recent changes to how rubygems and bundler are shipped require setting the build to use a specific version for rubygems during the rails setup process.