### PR TITLE
Patch recipe NodeJS

### DIFF
--- a/chef/cookbooks/metasploitable/recipes/nodejs.rb
+++ b/chef/cookbooks/metasploitable/recipes/nodejs.rb
@@ -10,4 +10,6 @@ execute 'add nodejs 4 repository' do
   not_if { ::File.exist?('/usr/bin/node') }
 end
 
-package 'nodejs'
+package 'nodejs' do
+  options '--force-yes'
+end


### PR DESCRIPTION
```
virtualbox-iso: STDERR: E: There are problems and -y was used without --force-yes
virtualbox-iso: ---- End output of ["apt-get", "-q", "-y", "install", "nodejs=4.9.1-1nodesource1"] ----
virtualbox-iso: Ran ["apt-get", "-q", "-y", "install", "nodejs=4.9.1-1nodesource1"] returned 100
virtualbox-iso: [2021-03-28T06:54:39+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
virtualbox-iso: [2021-03-28T06:54:39+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

This error is also present when building the vmware box for Ubuntu 14.04.

Fix from @russdan on https://github.com/rapid7/metasploitable3/issues/515