### PR TITLE
guard token in ManageEngine install

### DIFF
--- a/scripts/installs/install_manageengine.bat
+++ b/scripts/installs/install_manageengine.bat
@@ -1,5 +1,5 @@
 powershell -Command "[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true} ; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://metasploitable-binaries.s3.amazonaws.com/metasploitable3/ManageEngine_DesktopCentral.exe', 'C:\Windows\Temp\ManageEngine_DesktopCentral.exe')" <NUL
-start /WAIT C:\Windows\Temp\ManageEngine_DesktopCentral.exe /w /s /f1C:\Vagrant\resources\manageengine\setup.iss
+start /WAIT C:\Windows\Temp\ManageEngine_DesktopCentral.exe /w /s /f1"C:\Vagrant\resources\manageengine\setup.iss"
 net stop "ManageEngine Desktop Central Server"
 net stop "MEDC Server Component - Apache"
 net stop "MEDC Server Component - Notification Server"


### PR DESCRIPTION
This fix suggested by @nem0n in #438

Ensures ManageEngine install is parsed accurately