### PR TITLE
Range of IP address of the linux machine invalid.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure("2") do |config|
     config.ssh.username = 'vagrant'
     config.ssh.password = 'vagrant'
 
-    ub1404.vm.network "private_network", ip: '172.28.128.3'
+    ub1404.vm.network "private_network", ip: '192.168.56.5'
 
     ub1404.vm.provider "virtualbox" do |v|
       v.name = "Metasploitable3-ub1404"


### PR DESCRIPTION
The range of the IP address of the metasploitable Linux virtual machine should be between 192.168.56.0 and 192.168.56.21.  Otherwise a error occurs as following...

```
The IP address configured for the host-only network is not within the
allowed ranges. Please update the address used to be within the allowed
ranges and run the command again.

  Address: 172.28.128.3
  Ranges: 192.168.56.0/21

Valid ranges can be modified in the /etc/vbox/networks.conf file. For
more information including valid format see:

  https://www.virtualbox.org/manual/ch06.html#network_hostonly

```