### PR TITLE
Update configure_firewall.bat

### DIFF
--- a/scripts/configs/configure_firewall.bat
+++ b/scripts/configs/configure_firewall.bat
@@ -4,7 +4,7 @@ netsh advfirewall firewall add rule name="Open Port 80 for IIS" dir=in action=al
 netsh advfirewall firewall add rule name="Open Port 4848 for GlassFish" dir=in action=allow protocol=TCP localport=4848
 netsh advfirewall firewall add rule name="Open Port 8080 for GlassFish" dir=in action=allow protocol=TCP localport=8080
 netsh advfirewall firewall add rule name="Open Port 8585 for Wordpress and phpMyAdmin" dir=in action=allow protocol=TCP localport=8585
-netsh advfirewall firewall add rule name="Java 1.6 java.exe" dir=in action=allow program="C:\openjdk6\openjdk-1.6.0-unofficial-b27-windows-amd64\jre\bin\java.exe" enable=yes
+netsh advfirewall firewall add rule name="Java 1.6 java.exe" dir=in action=allow program="C:\openjdk7\openjdk-1.7.0-u80-unofficial-windows-amd64-installer\jre\bin\java.exe" enable=yes
 netsh advfirewall firewall add rule name="Open Port 3000 for Rails Server" dir=in action=allow protocol=TCP localport=3000
 netsh advfirewall firewall add rule name="Open Port 8020 for ManageEngine Desktop Central" dir=in action=allow protocol=TCP localport=8020
 netsh advfirewall firewall add rule name="Open Port 8383 for ManageEngine Desktop Central" dir=in action=allow protocol=TCP localport=8383


### PR DESCRIPTION
Other pullrequests to change the openjdk6 to openjdk7.
#595 

Changed line 7 from
C:\openjdk6\openjdk-1.6.0-unofficial-b27-windows-amd64\jre\bin\java.exe

to 
C:\openjdk7\openjdk-1.7.0-u80-unofficial-windows-amd64-installer\jre\bin\java.exe

The openjdk6 is outdated, see the pull reques #595 for changes for file name from openjdk6 to openjdk7.