### PR TITLE
Update windows_2008_r2.json

### DIFF
--- a/packer/templates/windows_2008_r2.json
+++ b/packer/templates/windows_2008_r2.json
@@ -287,7 +287,7 @@
         "{{user `scripts_dir`}}/installs/install_wamp.bat",
         "{{user `scripts_dir`}}/installs/start_wamp.bat",
         "{{user `scripts_dir`}}/installs/install_wordpress.bat",
-        "{{user `scripts_dir`}}/installs/install_openjdk6.bat",
+        "{{user `scripts_dir`}}/installs/install_openjdk7.bat",
         "{{user `scripts_dir`}}/installs/setup_jmx.bat",
         "{{user `scripts_dir`}}/chocolatey_installs/ruby.bat",
         "{{user `scripts_dir`}}/installs/install_devkit.bat"


### PR DESCRIPTION
Other pullrequests to change the openjdk6 to openjdk7.
#595
 Pull requested for another file. Compenstating filename changes in other files as well. The file name and jdk have been deprecated. The openjdk6 is not being used and openjdk7 is being utilized.

Changed    "{{user `scripts_dir`}}/installs/install_openjdk6.bat" to 
    "{{user `scripts_dir`}}/installs/install_openjdk7.bat".