### PR TITLE
remove expired DST root CA

### DIFF
--- a/chef/cookbooks/metasploitable/recipes/system_config.rb
+++ b/chef/cookbooks/metasploitable/recipes/system_config.rb
@@ -1,0 +1,11 @@
+# See https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/ and https://github.com/chef/chef/issues/12126
+
+bash 'disable expired DST Root CA X3 certificate' do
+    code <<-EOS 
+        sed -i 's:^mozilla/DST_Root_CA_X3.crt:!mozilla/DST_Root_CA_X3.crt:' /etc/ca-certificates.conf
+        update-ca-certificates
+    EOS
+    not_if "grep -q '^!mozilla/DST_Root_CA_X3.crt' /etc/ca-certificates.conf"
+end
+
+ENV['SSL_CERT_FILE'] = '/etc/ssl/certs/ca-certificates.crt'

--- a/chef/dev/ub1404/Vagrantfile
+++ b/chef/dev/ub1404/Vagrantfile
@@ -24,6 +24,7 @@ Vagrant.configure("2") do |config|
 
     chef.add_recipe "apt::default"
     chef.add_recipe "iptables::default"
+    chef.add_recipe "metasploitable:system_config"
     chef.add_recipe "metasploitable::users"
     chef.add_recipe "metasploitable::mysql"
     chef.add_recipe "metasploitable::apache_continuum"

--- a/packer/templates/ubuntu_1404.json
+++ b/packer/templates/ubuntu_1404.json
@@ -158,6 +158,8 @@
       ],
       "run_list": [
         "apt::default",
+        "iptables::default",
+        "metasploitable::system_config",
         "metasploitable::users",
         "metasploitable::mysql",
         "metasploitable::apache_continuum",


### PR DESCRIPTION
see https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/:

> The currently recommended certificate chain as presented to Let’s Encrypt ACME clients when new certificates are issued contains an intermediate certificate (ISRG Root X1) that is signed by an old DST Root CA X3 certificate that expires on 2021-09-30. In some cases the OpenSSL 1.0.2 version will regard the certificates issued by the Let’s Encrypt CA as having an expired trust chain.

(The Ubuntu VM is on OpenSSL 1.0.1f)

closes #590