### PR TITLE
add a status function to proftpd service file

### DIFF
--- a/chef/cookbooks/metasploitable/files/proftpd/proftpd
+++ b/chef/cookbooks/metasploitable/files/proftpd/proftpd
@@ -26,6 +26,19 @@ do_stop()
    killall proftpd
 }
 
+do_status()
+{
+   if pgrep -f ^proftpd > /dev/null ; then
+      echo 'Running';
+      exit 0;
+   else
+      echo 'Not running';
+      exit 1;
+   fi
+
+}
+
+
 
 case "$1" in
    start)
@@ -33,6 +46,9 @@ case "$1" in
      ;;
    stop)
      do_stop
+     ;;
+   status)
+     do_status
      ;;
 esac
 

--- a/chef/cookbooks/metasploitable/recipes/proftpd.rb
+++ b/chef/cookbooks/metasploitable/recipes/proftpd.rb
@@ -85,6 +85,7 @@ end
 
 service 'proftpd' do
   action [:enable, :start]
+  supports :status => true
 end
 
 service 'proftpd_ip_renewer' do


### PR DESCRIPTION
Without it, chef wouldn't actually start the service, concluding for some reason I haven't quite pinned down yet that the service was already running. Perhaps I didn't notice because the service would come up on reboot due to `enable` working (I think).

An alternative would be to bypass chef's checks and do a chef `execute do command service start`, but I think this is cleaner?

The matching pattern for pgrep is `^proftpd` is because the server shows up as `proftpd: (accepting connections)` The matching against the full line(`-f`) in combination with `^` is needed because otherwise pgrep also matches against `/etc/init.d/proftpd`, which maybe is why chef was failing in the first place?

this might be affecting other metasploitable services...