### PR TITLE
update to https URL to avoid failure to redirect

### DIFF
--- a/scripts/installs/setup_axis2.bat
+++ b/scripts/installs/setup_axis2.bat
@@ -1,4 +1,4 @@
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://archive.apache.org/dist/axis/axis2/java/core/1.6.0/axis2-1.6.0-war.zip', 'C:\Windows\Temp\axis2-1.6.0-war.zip')" <NUL
+powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://archive.apache.org/dist/axis/axis2/java/core/1.6.0/axis2-1.6.0-war.zip', 'C:\Windows\Temp\axis2-1.6.0-war.zip')" <NUL
 cmd /c ""C:\Program Files\7-Zip\7z.exe" x "C:\Windows\Temp\axis2-1.6.0-war.zip" -oC:\axis2"
 copy /Y C:\axis2\axis2.war "%CATALINA_HOME%\webapps"
 rd /s /q C:\axis2


### PR DESCRIPTION
Fix #618 

The `axis2-1.6.0-war.zip` package hosted by apache.org now redirects to `https` windows 2008 needs `Tls1.2` enabled to follow the redirect.